### PR TITLE
bCourses site creation test script enhancement

### DIFF
--- a/pages/calcentral/canvas_site_creation_page.rb
+++ b/pages/calcentral/canvas_site_creation_page.rb
@@ -40,20 +40,6 @@ module Page
         wait_for_page_update_and_click create_project_site_link_element
       end
 
-      # Masquerades as a user if necessary and navigates from the Canvas homepage to the create a course site page
-      # @param driver [Selenium::WebDriver]
-      # @param course [Course]
-      # @param instructor [User]
-      # @param canvas [Page::CanvasPage]
-      # @param create_course_site [Page::CalCentralPages::CanvasCreateCourseSitePage]
-      def choose_course_site(driver, course, instructor, canvas, create_course_site)
-        canvas.stop_masquerading if canvas.stop_masquerading_link?
-        canvas.masquerade_as(instructor, course) if course.create_site_workflow == 'masquerade'
-        canvas.load_homepage
-        canvas.click_create_site driver
-        click_create_course_site create_course_site
-      end
-
     end
   end
 end

--- a/pages/canvas_page.rb
+++ b/pages/canvas_page.rb
@@ -51,6 +51,7 @@ module Page
     # @param course [Course]
     def masquerade_as(user, course = nil)
       logger.info "Masquerading as UID #{user.uid} #{user.role} #{user.username}"
+      stop_masquerading if stop_masquerading_link?
       navigate_to "#{Utils.canvas_base_url}/users/#{user.canvas_id.to_s}/masquerade"
       wait_for_page_load_and_click masquerade_link_element
       stop_masquerading_link_element.when_visible

--- a/settings.yml
+++ b/settings.yml
@@ -30,6 +30,7 @@ calcentral:
 users:
   super_admin_username: secret
   super_admin_password: secret
+  super_admin_uid: secret
   ets_qa_username: secret
   ets_qa_password: secret
   test_user_password: secret

--- a/spec/junction/canvas_lti_course_captures_spec.rb
+++ b/spec/junction/canvas_lti_course_captures_spec.rb
@@ -4,6 +4,8 @@ describe 'bCourses Course Captures tool' do
 
   include Logging
 
+  masquerade = ENV['masquerade']
+
   begin
 
     # The test data file should contain data variations such as cross-listings and courses with multiple primary sections
@@ -12,7 +14,7 @@ describe 'bCourses Course Captures tool' do
     @driver = Utils.launch_browser
     @course_captures_page = Page::CalCentralPages::CanvasCourseCapturesPage.new @driver
 
-    if ENV['masquerade']
+    if masquerade
       @cal_net = Page::CalNetPage.new @driver
       @canvas = Page::CanvasPage.new @driver
       @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
@@ -34,13 +36,13 @@ describe 'bCourses Course Captures tool' do
           canvas_content.each do |course_site|
             course = Course.new({site_id: "#{course_site['siteId']}"})
 
-            if ENV['masquerade']
+            if masquerade
               @canvas.masquerade_as(user, course)
               @course_captures_page.load_embedded_tool(@driver, course)
             else
               @splash_page.load_page
               @splash_page.basic_auth user.uid
-              @course_captures_page.load_standalone_tool(@driver, course)
+              @course_captures_page.load_standalone_tool course
             end
 
             expected_sections = course_site['sections']

--- a/spec/junction/canvas_lti_course_site_creation_spec.rb
+++ b/spec/junction/canvas_lti_course_site_creation_spec.rb
@@ -4,6 +4,9 @@ describe 'bCourses course site creation' do
 
   include Logging
 
+  masquerade = ENV['masquerade']
+  links_tested = false
+
   begin
     @driver = Utils.launch_browser
     test_output = Utils.initialize_canvas_test_output(self, ['Term', 'Course Code', 'Instructor', 'Site ID', 'Students', 'Waitlist Students', 'Teachers', 'TAs'])
@@ -14,10 +17,13 @@ describe 'bCourses course site creation' do
     @site_creation_page = Page::CalCentralPages::CanvasSiteCreationPage.new @driver
     @create_course_site_page = Page::CalCentralPages::CanvasCreateCourseSitePage.new @driver
     @canvas_page = Page::CanvasPage.new @driver
+    @roster_photos_page = Page::CalCentralPages::CanvasRostersPage.new @driver
+    @course_captures_page = Page::CalCentralPages::CanvasCourseCapturesPage.new @driver
 
-    links_tested = false
-
-    @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password)
+    # Authenticate in Canvas
+    masquerade ?
+        @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password) :
+        @canvas_page.log_in(@cal_net_page, Utils.ets_qa_username, Utils.ets_qa_password)
 
     test_courses = Utils.load_test_courses.select { |course| course['tests']['create_course_site'] }
     test_courses.each do |course|
@@ -32,9 +38,22 @@ describe 'bCourses course site creation' do
 
         logger.info "Creating a course site for #{@course.code} in #{@course.term} using the '#{@course.create_site_workflow}' workflow"
 
-        @site_creation_page.choose_course_site(@driver, @course, @teacher, @canvas_page, @create_course_site_page)
+        # Navigate to Create a Course Site page
+        if masquerade
+          @canvas_page.masquerade_as @teacher unless %w(uid ccn).include?(@course.create_site_workflow)
+          @canvas_page.load_homepage
+          @canvas_page.click_create_site @driver
+        else
+          @splash_page.load_page
+          (%w(uid ccn).include?(@course.create_site_workflow)) ?
+              @splash_page.basic_auth(Utils.super_admin_uid) :
+              @splash_page.basic_auth(@teacher.uid)
+          @site_creation_page.load_page
+        end
+        @site_creation_page.click_create_course_site @create_course_site_page
         @create_course_site_page.search_for_course(@course, @teacher, sections_for_site)
 
+        # Verify page content and external links for one of the courses
         unless links_tested
 
           @create_course_site_page.maintenance_button_element.when_visible Utils.short_wait
@@ -49,7 +68,7 @@ describe 'bCourses course site creation' do
           bcourses_link_works = @create_course_site_page.verify_external_link(@driver, @create_course_site_page.bcourses_service_element, 'bCourses | Educational Technology Services')
           it ('shows a link to the bCourses service page') { expect(bcourses_link_works).to be true }
 
-          @canvas_page.switch_to_canvas_iframe @driver
+          @canvas_page.switch_to_canvas_iframe(@driver) if masquerade
           @create_course_site_page.click_need_help
 
           help_text = @create_course_site_page.help
@@ -59,14 +78,15 @@ describe 'bCourses course site creation' do
 
         end
 
+        # Unless admin creates site by CCN list, all sections in the course should be shown
         @create_course_site_page.toggle_course_sections @course
-
         (@course.create_site_workflow == 'ccn') ?
             expected_section_ids = sections_for_site.map { |section| section.id } :
             expected_section_ids = sections.map { |section| section.id }
         visible_section_ids = @create_course_site_page.course_section_ids(@driver, @course)
         it ("offers all the expected sections for #{@course.term} #{@course.code}") { expect(visible_section_ids.sort!).to eql(expected_section_ids.sort!) }
 
+        # Choose sections and create site
         @create_course_site_page.select_sections sections_for_site
         @create_course_site_page.click_next
 
@@ -83,18 +103,45 @@ describe 'bCourses course site creation' do
 
         @create_course_site_page.click_create_site
 
+        # Wait for redirect to new Canvas course site
         site_created = @create_course_site_page.verify_block do
           @canvas_page.wait_until(Utils.long_wait) { @canvas_page.current_url.include? "#{Utils.canvas_base_url}/courses" }
         end
         it ("redirects to the #{@course.term} #{@course.code} course site in Canvas when finished") { expect(site_created).to be true }
 
-        # If site creation failed, don't check the site's enrollment
+        # If masquerading and if site creation succeeded, wait for enrollment to finish updating
         if site_created
           @course.site_id = @canvas_page.current_url.delete "#{Utils.canvas_base_url}/courses/"
           logger.info "Canvas course site ID is #{@course.site_id}"
+          enrollment_counts = @canvas_page.wait_for_enrollment_import(@course, ['Student', 'Waitlist Student', 'Teacher', 'TA']) if masquerade
 
-          # Wait for enrollment to finish updating for each user role type and then store the count for each type
-          enrollment_counts = @canvas_page.wait_for_enrollment_import(@course, ['Student', 'Waitlist Student', 'Teacher', 'TA'])
+          # Check roster photos tool and verify it shows the right sections
+          if masquerade
+            has_roster_photos_link = @roster_photos_page.roster_photos_link?
+            it ("shows a Roster Photos tool link in course site navigation for #{@course.term} #{@course.code} site ID #{@course.site_id}") { expect(has_roster_photos_link).to be true }
+
+            @canvas_page.masquerade_as(@teacher, @course)
+            @roster_photos_page.load_embedded_tool(@driver, @course)
+          else
+            @roster_photos_page.load_standalone_tool @course
+          end
+          @roster_photos_page.section_select_element.when_visible Utils.medium_wait
+          expected_sections_on_site = (sections_for_site.map { |section| section.code })
+          actual_sections_on_site = @roster_photos_page.section_select_options.delete 'All Sections'
+          it("shows the right section list on the Roster Photos tool for #{@course.term} #{@course.code} site ID #{@course.site_id}") { expect(actual_sections_on_site).to eql(expected_sections_on_site) }
+
+          # Check course capture tool and verify it shows a 'no captures' message
+          if masquerade
+            has_course_captures_link = @course_captures_page.course_captures_link?
+            it ("shows no Course Captures tool link in course site navigation for #{@course.term} #{@course.code} site ID #{@course.site_id}") { expect(has_course_captures_link).to be false }
+
+            @course_captures_page.load_embedded_tool(@driver, @course)
+          else
+            @course_captures_page.load_standalone_tool @course
+          end
+          no_captures = @course_captures_page.no_course_capture_msg.when_visible Utils.medium_wait
+          it ("shows a 'no videos' message for #{@course.term} #{@course.code} site ID #{@course.site_id}") { expect(no_captures).to be_truthy }
+
         else
           logger.error "Timed out before the #{@course.term} #{@course.code} course site was created, or another error occurred"
         end

--- a/util/utils.rb
+++ b/util/utils.rb
@@ -205,6 +205,10 @@ class Utils
     @config['users']['super_admin_password']
   end
 
+  def self.super_admin_uid
+    @config['users']['super_admin_uid']
+  end
+
   def self.ets_qa_username
     @config['users']['ets_qa_username']
   end


### PR DESCRIPTION
Changes to site creation script:

- allow test runs using embedded tool (on a local machine) or standalone tool (either locally or on a server)
- add post-site-creation checks for roster photos and course captures tools