### PR TITLE
SuiteC test updates for v1.8

### DIFF
--- a/pages/suitec/asset_library_page.rb
+++ b/pages/suitec/asset_library_page.rb
@@ -24,6 +24,8 @@ module Page
       div(:resume_sync_success, xpath: '//div[contains(.,"Syncing has been resumed for this course. There may be a short delay before SuiteC tools are updated.")]')
 
       # Checks if Canvas sync is disabled. If so, adds an asset to create new activity and resumes sync.
+      # @param driver [Selenium::WebDriver]
+      # @param url [String]
       def ensure_canvas_sync(driver, url)
         load_page(driver, url)
         add_site_link_element.when_visible Utils.short_wait

--- a/pages/suitec/asset_library_page.rb
+++ b/pages/suitec/asset_library_page.rb
@@ -20,6 +20,24 @@ module Page
         switch_to_canvas_iframe driver
       end
 
+      button(:resume_sync_button, xpath: '//button[contains(.,"Resume syncing")]')
+      div(:resume_sync_success, xpath: '//div[contains(.,"Syncing has been resumed for this course. There may be a short delay before SuiteC tools are updated.")]')
+
+      # Checks if Canvas sync is disabled. If so, adds an asset to create new activity and resumes sync.
+      def ensure_canvas_sync(driver, url)
+        load_page(driver, url)
+        add_site_link_element.when_visible Utils.short_wait
+        if resume_sync_button?
+          add_site Asset.new({ url: 'www.google.com', title: 'resume sync asset' })
+          logger.info 'Syncing is disabled for this course site, re-enabling'
+          wait_for_page_update_and_click resume_sync_button_element
+          resume_sync_success_element.when_visible Utils.short_wait
+          sleep Utils.medium_wait
+        else
+          logger.info 'Syncing is still enabled for this course site'
+        end
+      end
+
       # ASSETS
 
       elements(:list_view_asset, :list_item, class: 'assetlibrary-list-item')
@@ -85,10 +103,7 @@ module Page
       # Waits for an asset's detail view to load
       # @param asset [Asset]
       def wait_for_asset_detail(asset)
-        wait_until(Utils.short_wait) do
-          logger.debug "Visible asset title should include '#{asset.title}' and is currently '#{detail_view_asset_title}'"
-          detail_view_asset_title.include? "#{asset.title}"
-        end
+        wait_until(Utils.short_wait) { detail_view_asset_title.include? "#{asset.title}" }
       end
 
       # Combines methods to load the asset library, find a given asset, and load its detail view
@@ -169,7 +184,8 @@ module Page
       # @param asset [Asset]
       # @return [boolean]
       def preview_generated?(driver, url, asset)
-        logger.info "Verifying a preview of type '#{asset.preview}' is generated for the asset"
+        timeout = Utils.medium_wait
+        logger.info "Verifying a preview of type '#{asset.preview}' is generated for the asset within #{timeout} seconds"
         preview_element = case asset.preview
                             when 'image'
                               image_element(xpath: '//div[@id="assetlibrary-item-preview"]//div[@data-ng-if="asset.type === \'file\' && asset.image_url !== null"]/img')
@@ -187,9 +203,11 @@ module Page
                               paragraph_element(xpath: '//p[contains(.,"No preview available")]')
                           end
         load_asset_detail(driver, url, asset)
-        preparing_preview_element.when_not_present(Utils.medium_wait) if preparing_preview?
-        sleep 1
-        preview_element.exists?
+        verify_block do
+          preparing_preview_element.when_not_present(timeout) if preparing_preview?
+          sleep 1
+          preview_element.when_present Utils.short_wait
+        end
       end
 
       # SEARCH / FILTER

--- a/pages/suitec/whiteboards_page.rb
+++ b/pages/suitec/whiteboards_page.rb
@@ -48,7 +48,7 @@ module Page
       # @param user [User]
       # @return [PageObject::Elements::Element]
       def collaborator_option_link(user)
-        link_element(xpath: "//li[contains(@class,'select-dropdown-optgroup-option')][contains(text(),'#{user.full_name}')]")
+        button_element(xpath: "//li[contains(@class,'select-dropdown-optgroup-option')][contains(text(),'#{user.full_name}')]")
       end
 
       # Returns the element indicating that a user is an existing whiteboard collaborator
@@ -108,8 +108,10 @@ module Page
       # Opens a whiteboard directly via URL
       # @param course [Course]
       # @param whiteboard [Whiteboard]
-      def hit_whiteboard_url(course, whiteboard)
-        navigate_to "#{Utils.suite_c_base_url}/whiteboards/#{whiteboard.id}?api_domain=#{Utils.canvas_base_url[8..38]}/courses/#{course.site_id}"
+      def hit_whiteboard_url(course, whiteboards_url, whiteboard)
+        url = "#{Utils.suite_c_base_url}/whiteboards/#{whiteboard.id}?api_domain=#{Utils.canvas_base_url[8..-1]}&course_id=#{course.site_id}&tool_url=#{whiteboards_url}"
+        logger.debug "Hitting URL '#{url}'"
+        navigate_to url
       end
 
       # Closes a browser window if it contains a whiteboard and if more than one window is open

--- a/spec/suitec/asset_library_manage_assets_spec.rb
+++ b/spec/suitec/asset_library_manage_assets_spec.rb
@@ -6,16 +6,18 @@ describe 'Asset', order: :defined do
 
   test_id = Utils.get_test_id
 
+  # Get test users
+  user_test_data = Utils.load_test_users.select { |data| data['tests']['assetLibraryCategorySearch'] }
+  users = user_test_data.map { |data| User.new(data) if ['Teacher', 'Designer', 'Lead TA', 'TA', 'Observer', 'Reader', 'Student'].include? data['role'] }
+  teacher = users.find { |user| user.role == 'Teacher' }
+  students = users.select { |user| user.role == 'Student' }
+  student_uploader = students[0]
+  student_viewer = students[1]
+  asset = Asset.new (student_uploader.assets.find { |asset| asset['type'] == 'Link' })
+
   before(:all) do
     @course = Course.new({})
     @course.site_id = ENV['course_id']
-
-    test_users = Utils.load_test_users.select { |user| user['tests']['assetLibraryManageAssets'] }
-    @teacher = User.new test_users.find { |user| user['role'] == 'Teacher' }
-    test_students = test_users.select { |user| user['role'] == 'Student' }
-    @student_uploader = User.new test_students[0]
-    @student_viewer = User.new test_students[1]
-    @asset = Asset.new (@student_uploader.assets.find { |asset| asset['type'] == 'Link' })
 
     @driver = Utils.launch_browser
     @canvas = Page::CanvasPage.new @driver
@@ -26,7 +28,7 @@ describe 'Asset', order: :defined do
 
     # Obtain course site and add two new asset categories
     @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
-    @canvas.get_suite_c_test_course(@course, [@teacher, @student_uploader, @student_viewer], test_id, [SuiteCTools::ASSET_LIBRARY, SuiteCTools::ENGAGEMENT_INDEX, SuiteCTools::WHITEBOARDS])
+    @canvas.get_suite_c_test_course(@course, users, test_id, [SuiteCTools::ASSET_LIBRARY, SuiteCTools::ENGAGEMENT_INDEX, SuiteCTools::WHITEBOARDS])
     @whiteboards_url = @canvas.click_tool_link(@driver, SuiteCTools::WHITEBOARDS)
     @engagement_index_url = @canvas.click_tool_link(@driver, SuiteCTools::ENGAGEMENT_INDEX)
     @asset_library_url = @canvas.click_tool_link(@driver, SuiteCTools::ASSET_LIBRARY)
@@ -39,48 +41,48 @@ describe 'Asset', order: :defined do
 
     before(:all) do
       # Upload a new asset for the test
-      @canvas.masquerade_as(@student_uploader, @course)
+      @canvas.masquerade_as(student_uploader, @course)
       @asset_library.load_page(@driver, @asset_library_url)
-      @asset.title = "#{Time.now.to_i}"
-      @asset.category = @category_1
-      @asset_library.add_site @asset
-      logger.debug "Asset ID #{@asset.id} has title '#{@asset.title}'"
+      asset.title = "#{Time.now.to_i}"
+      asset.category = @category_1
+      @asset_library.add_site asset
+      logger.debug "Asset ID #{asset.id} has title '#{asset.title}'"
 
-      @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+      @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
       @asset_library.add_comment 'An asset comment'
       @asset_library.toggle_detail_view_item_like
     end
 
     it 'are not allowed if the user is a student who is not the asset creator' do
-      @canvas.masquerade_as(@student_viewer, @course)
-      @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+      @canvas.masquerade_as(student_viewer, @course)
+      @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
       expect(@asset_library.edit_details_link_element.visible?).to be false
     end
 
     it 'are allowed if the user is a teacher' do
-      @canvas.masquerade_as(@teacher, @course)
-      @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+      @canvas.masquerade_as(teacher, @course)
+      @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
 
-      @asset.title = "#{@asset.title} - edited by teacher"
-      @asset.category = @category_2
-      @asset.description = 'Description edited by teacher'
+      asset.title = "#{asset.title} - edited by teacher"
+      asset.category = @category_2
+      asset.description = 'Description edited by teacher'
 
-      @asset_library.edit_asset_details @asset
-      @asset_library.load_list_view_asset(@driver, @asset_library_url, @asset)
-      @asset_library.verify_first_asset(@student_uploader, @asset)
+      @asset_library.edit_asset_details asset
+      @asset_library.load_list_view_asset(@driver, @asset_library_url, asset)
+      @asset_library.verify_first_asset(student_uploader, asset)
     end
 
     it 'are allowed if the user is a student who is the asset creator' do
-      @canvas.masquerade_as(@student_uploader, @course)
-      @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+      @canvas.masquerade_as(student_uploader, @course)
+      @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
 
-      @asset.title = "#{@asset.title} - edited by student"
-      @asset.category = nil
-      @asset.description = 'Description edited by student'
+      asset.title = "#{asset.title} - edited by student"
+      asset.category = nil
+      asset.description = 'Description edited by student'
 
-      @asset_library.edit_asset_details @asset
-      @asset_library.load_list_view_asset(@driver, @asset_library_url, @asset)
-      @asset_library.verify_first_asset(@student_uploader, @asset)
+      @asset_library.edit_asset_details asset
+      @asset_library.load_list_view_asset(@driver, @asset_library_url, asset)
+      @asset_library.verify_first_asset(student_uploader, asset)
     end
   end
 
@@ -90,51 +92,51 @@ describe 'Asset', order: :defined do
 
       before(:each) do
         # Upload a new asset for the test
-        @asset.title = "#{Time.now.to_i}"
-        @canvas.masquerade_as(@student_uploader, @course)
+        asset.title = "#{Time.now.to_i}"
+        @canvas.masquerade_as(student_uploader, @course)
         @asset_library.load_page(@driver, @asset_library_url)
-        @asset_library.add_site @asset
-        logger.debug "Asset ID #{@asset.id} has title '#{@asset.title}'"
+        @asset_library.add_site asset
+        logger.debug "Asset ID #{asset.id} has title '#{asset.title}'"
 
         # Get the students' initial scores
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        @uploader_score = @engagement_index.user_score @student_uploader
+        @uploader_score = @engagement_index.user_score student_uploader
       end
 
       it 'can be done by a teacher with no effect on points already earned' do
         # Delete asset
-        @canvas.masquerade_as(@teacher, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(teacher, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         @asset_library.delete_asset
-        @asset_library.advanced_search(test_id, nil, @student_uploader, nil)
+        @asset_library.advanced_search(test_id, nil, student_uploader, nil)
         @asset_library.no_search_results_element.when_present Utils.short_wait
 
         # Check points
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        expect(@engagement_index.user_score @student_uploader).to eql(@uploader_score)
+        expect(@engagement_index.user_score student_uploader).to eql(@uploader_score)
         scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@student_uploader.full_name}, add_asset, #{Activities::ADD_ASSET_TO_LIBRARY.points}, #{@uploader_score}")
+        expect(scores).to include("#{student_uploader.full_name}, add_asset, #{Activities::ADD_ASSET_TO_LIBRARY.points}, #{@uploader_score}")
       end
 
       it 'can be done by the student who created the asset with no effect on points already earned' do
         # Delete asset
-        @canvas.masquerade_as(@student_uploader, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_uploader, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         @asset_library.delete_asset
-        @asset_library.advanced_search(test_id, nil, @student_uploader, nil)
+        @asset_library.advanced_search(test_id, nil, student_uploader, nil)
         @asset_library.no_search_results_element.when_present Utils.short_wait
 
         # Check points
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        expect(@engagement_index.user_score @student_uploader).to eql(@uploader_score)
+        expect(@engagement_index.user_score student_uploader).to eql(@uploader_score)
       end
 
       it 'cannot be done by a student who did not create the asset' do
-        @canvas.masquerade_as(@student_viewer, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_viewer, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         expect(@asset_library.delete_asset_button?).to be false
       end
 
@@ -144,51 +146,51 @@ describe 'Asset', order: :defined do
 
       before(:each) do
         # Upload a new asset for the test
-        @asset.title = "#{Time.now.to_i}"
-        @canvas.masquerade_as(@student_uploader, @course)
+        asset.title = "#{Time.now.to_i}"
+        @canvas.masquerade_as(student_uploader, @course)
         @asset_library.load_page(@driver, @asset_library_url)
-        @asset_library.add_site @asset
-        logger.debug "Asset ID #{@asset.id} has title '#{@asset.title}'"
+        @asset_library.add_site asset
+        logger.debug "Asset ID #{asset.id} has title '#{asset.title}'"
 
         # Add a comment
-        @canvas.masquerade_as(@student_viewer, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_viewer, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         @asset_library.add_comment 'An asset comment'
 
         # Get the students' initial scores
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        @uploader_score = @engagement_index.user_score @student_uploader
-        @viewer_score = @engagement_index.user_score @student_viewer
+        @uploader_score = @engagement_index.user_score student_uploader
+        @viewer_score = @engagement_index.user_score student_viewer
       end
 
       it 'can be done by a teacher with no effect on points already earned' do
         # Delete asset
-        @canvas.masquerade_as(@teacher, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(teacher, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         @asset_library.delete_asset
-        @asset_library.advanced_search(test_id, nil, @student_uploader, nil)
+        @asset_library.advanced_search(test_id, nil, student_uploader, nil)
         @asset_library.no_search_results_element.when_present Utils.short_wait
 
         # Check points
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        expect(@engagement_index.user_score @student_uploader).to eql(@uploader_score)
-        expect(@engagement_index.user_score @student_viewer).to eql(@viewer_score)
+        expect(@engagement_index.user_score student_uploader).to eql(@uploader_score)
+        expect(@engagement_index.user_score student_viewer).to eql(@viewer_score)
         scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@student_uploader.full_name}, get_asset_comment, #{Activities::GET_COMMENT.points}, #{@uploader_score}")
-        expect(scores).to include("#{@student_viewer.full_name}, asset_comment, #{Activities::COMMENT.points}, #{@viewer_score}")
+        expect(scores).to include("#{student_uploader.full_name}, get_asset_comment, #{Activities::GET_COMMENT.points}, #{@uploader_score}")
+        expect(scores).to include("#{student_viewer.full_name}, asset_comment, #{Activities::COMMENT.points}, #{@viewer_score}")
       end
 
       it 'cannot be done by the student who created the asset' do
-        @canvas.masquerade_as(@student_uploader, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_uploader, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         expect(@asset_library.delete_asset_button?).to be false
       end
 
       it 'cannot be done by a student who did not create the asset' do
-        @canvas.masquerade_as(@student_viewer, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_viewer, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         expect(@asset_library.delete_asset_button?).to be false
       end
 
@@ -198,51 +200,51 @@ describe 'Asset', order: :defined do
 
       before(:each) do
         # Upload a new asset for the test
-        @asset.title = "#{Time.now.to_i}"
-        @canvas.masquerade_as(@student_uploader, @course)
+        asset.title = "#{Time.now.to_i}"
+        @canvas.masquerade_as(student_uploader, @course)
         @asset_library.load_page(@driver, @asset_library_url)
-        @asset_library.add_site @asset
-        logger.debug "Asset ID #{@asset.id} has title '#{@asset.title}'"
+        @asset_library.add_site asset
+        logger.debug "Asset ID #{asset.id} has title '#{asset.title}'"
 
         # Add a like
-        @canvas.masquerade_as(@student_viewer, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_viewer, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         @asset_library.toggle_detail_view_item_like
 
         # Get the students' initial scores
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        @uploader_score = @engagement_index.user_score @student_uploader
-        @viewer_score = @engagement_index.user_score @student_viewer
+        @uploader_score = @engagement_index.user_score student_uploader
+        @viewer_score = @engagement_index.user_score student_viewer
       end
 
       it 'can be done by a teacher with no effect on points already earned' do
         # Delete asset
-        @canvas.masquerade_as(@teacher, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(teacher, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         @asset_library.delete_asset
-        @asset_library.advanced_search(test_id, nil, @student_uploader, nil)
+        @asset_library.advanced_search(test_id, nil, student_uploader, nil)
         @asset_library.no_search_results_element.when_present Utils.short_wait
 
         # Check points
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        expect(@engagement_index.user_score @student_uploader).to eql(@uploader_score)
-        expect(@engagement_index.user_score @student_viewer).to eql(@viewer_score)
+        expect(@engagement_index.user_score student_uploader).to eql(@uploader_score)
+        expect(@engagement_index.user_score student_viewer).to eql(@viewer_score)
         scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@student_uploader.full_name}, get_like, #{Activities::GET_LIKE.points}, #{@uploader_score}")
-        expect(scores).to include("#{@student_viewer.full_name}, like, #{Activities::LIKE.points}, #{@viewer_score}")
+        expect(scores).to include("#{student_uploader.full_name}, get_like, #{Activities::GET_LIKE.points}, #{@uploader_score}")
+        expect(scores).to include("#{student_viewer.full_name}, like, #{Activities::LIKE.points}, #{@viewer_score}")
       end
 
       it 'cannot be done by the student who created the asset' do
-        @canvas.masquerade_as(@student_uploader, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_uploader, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         expect(@asset_library.delete_asset_button?).to be false
       end
 
       it 'cannot be done by a student who did not create the asset' do
-        @canvas.masquerade_as(@student_viewer, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_viewer, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         expect(@asset_library.delete_asset_button?).to be false
       end
 
@@ -252,20 +254,20 @@ describe 'Asset', order: :defined do
 
       before(:each) do
         # Upload a new asset for the test
-        @asset.title = "#{Time.now.to_i}"
-        @canvas.masquerade_as(@student_uploader, @course)
+        asset.title = "#{Time.now.to_i}"
+        @canvas.masquerade_as(student_uploader, @course)
         @asset_library.load_page(@driver, @asset_library_url)
-        @asset_library.add_site @asset
-        logger.debug "Asset ID #{@asset.id} has title '#{@asset.title}'"
+        @asset_library.add_site asset
+        logger.debug "Asset ID #{asset.id} has title '#{asset.title}'"
 
         # Add to a whiteboard
-        @whiteboard = Whiteboard.new({owner: @student_viewer, title: 'Test Whiteboard', collaborators: [@student_uploader]})
-        @canvas.masquerade_as(@student_viewer, @course)
+        @whiteboard = Whiteboard.new({owner: student_viewer, title: 'Test Whiteboard', collaborators: [student_uploader]})
+        @canvas.masquerade_as(student_viewer, @course)
         @whiteboards.load_page(@driver, @whiteboards_url)
         @whiteboards.create_whiteboard @whiteboard
         @whiteboards.open_whiteboard(@driver, @whiteboard)
         begin
-          @whiteboards.add_existing_assets [@asset]
+          @whiteboards.add_existing_assets [asset]
         ensure
           @whiteboards.close_whiteboard @driver
         end
@@ -273,38 +275,48 @@ describe 'Asset', order: :defined do
         # Get the students' initial scores
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        @uploader_score = @engagement_index.user_score @student_uploader
-        @viewer_score = @engagement_index.user_score @student_viewer
+        @uploader_score = @engagement_index.user_score student_uploader
+        @viewer_score = @engagement_index.user_score student_viewer
       end
 
       it 'can be done by a teacher with no effect on points already earned' do
         # Delete asset
-        @canvas.masquerade_as(@teacher, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(teacher, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         @asset_library.delete_asset
-        @asset_library.advanced_search(test_id, nil, @student_uploader, nil)
+        @asset_library.advanced_search(test_id, nil, student_uploader, nil)
         @asset_library.no_search_results_element.when_present Utils.short_wait
 
         # Check points
         @canvas.stop_masquerading
         @engagement_index.load_page(@driver, @engagement_index_url)
-        expect(@engagement_index.user_score @student_uploader).to eql(@uploader_score)
-        expect(@engagement_index.user_score @student_viewer).to eql(@viewer_score)
+        expect(@engagement_index.user_score student_uploader).to eql(@uploader_score)
+        expect(@engagement_index.user_score student_viewer).to eql(@viewer_score)
         # TODO: verify that whiteboard points remain on csv
       end
 
       it 'cannot be done by the student who created the asset' do
-        @canvas.masquerade_as(@student_uploader, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_uploader, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         expect(@asset_library.delete_asset_button?).to be false
       end
 
       it 'cannot be done by a student who did not create the asset' do
-        @canvas.masquerade_as(@student_viewer, @course)
-        @asset_library.load_asset_detail(@driver, @asset_library_url, @asset)
+        @canvas.masquerade_as(student_viewer, @course)
+        @asset_library.load_asset_detail(@driver, @asset_library_url, asset)
         expect(@asset_library.delete_asset_button?).to be false
       end
 
+    end
+  end
+
+  describe 'files in Canvas' do
+
+    users.each do |user|
+      it "are visible to course #{user.role} UID #{user.uid} if the user has permission to see them" do
+        @canvas.masquerade_as(user, @course)
+        expect(@canvas.suitec_files_hidden?(@course, user)).to be true
+      end
     end
   end
 
@@ -316,12 +328,12 @@ describe 'Asset', order: :defined do
       # Create a destination course site with an asset library for asset migration
       destination_test_id = Utils.get_test_id
       @destination_course = Course.new({})
-      @canvas.get_suite_c_test_course(@destination_course, [@teacher], destination_test_id, [SuiteCTools::ASSET_LIBRARY])
+      @canvas.get_suite_c_test_course(@destination_course, [teacher], destination_test_id, [SuiteCTools::ASSET_LIBRARY])
       @destination_library = Page::SuiteCPages::AssetLibraryPage.new @driver
       @destination_library_url = @canvas.click_tool_link(@driver, SuiteCTools::ASSET_LIBRARY)
 
       # Teacher logs in to new asset library so that enrollment is synced immediately
-      @canvas.masquerade_as(@teacher, @destination_course)
+      @canvas.masquerade_as(teacher, @destination_course)
       @destination_library.load_page(@driver, @destination_library_url)
 
       # Teacher creates an asset of each type in origin course site plus one extra that is deleted
@@ -337,7 +349,7 @@ describe 'Asset', order: :defined do
       @migrated_file = Asset.new({type: 'File', file_name: 'image-jpegSmall1.jpg', title: "#{destination_test_id} - Migrated File", category: @category_1})
       @asset_library.upload_file_to_library @migrated_file
 
-      @non_migrated_whiteboard = Whiteboard.new({owner: @teacher, title: "#{destination_test_id} - Migrated Whiteboard", collaborators: []})
+      @non_migrated_whiteboard = Whiteboard.new({owner: teacher, title: "#{destination_test_id} - Migrated Whiteboard", collaborators: []})
       @whiteboards.load_page(@driver, @whiteboards_url)
       @whiteboards.create_whiteboard @non_migrated_whiteboard
       @whiteboards.open_whiteboard(@driver, @non_migrated_whiteboard)
@@ -352,10 +364,10 @@ describe 'Asset', order: :defined do
       @asset_library.migrate_assets(@driver, @asset_library_url, @destination_course)
     end
 
-    it('copies File type assets') { expect(@destination_library.asset_migrated?(@driver, @destination_library_url, @migrated_file, @teacher)).to be true }
-    it('copies Link type assets') { expect(@destination_library.asset_migrated?(@driver, @destination_library_url, @migrated_link, @teacher)).to be true }
-    it('does not copy Whiteboard type assets') { expect(@destination_library.asset_migrated?(@driver, @destination_library_url, @migrated_whiteboard, @teacher)).to be false }
-    it('does not copy deleted assets') { expect(@destination_library.asset_migrated?(@driver, @destination_library_url, @non_migrated_delete, @teacher)).to be false }
+    it('copies File type assets') { expect(@destination_library.asset_migrated?(@driver, @destination_library_url, @migrated_file, teacher)).to be true }
+    it('copies Link type assets') { expect(@destination_library.asset_migrated?(@driver, @destination_library_url, @migrated_link, teacher)).to be true }
+    it('does not copy Whiteboard type assets') { expect(@destination_library.asset_migrated?(@driver, @destination_library_url, @migrated_whiteboard, teacher)).to be false }
+    it('does not copy deleted assets') { expect(@destination_library.asset_migrated?(@driver, @destination_library_url, @non_migrated_delete, teacher)).to be false }
 
   end
 end

--- a/spec/suitec/canvas_assignment_sync_spec.rb
+++ b/spec/suitec/canvas_assignment_sync_spec.rb
@@ -4,11 +4,12 @@ include Logging
 
 describe 'Canvas assignment sync', order: :defined do
 
+  course_id = ENV['course_id']
   test_id = Utils.get_test_id
 
   before(:all) do
     @course = Course.new({})
-    @course.site_id = ENV['course_id']
+    @course.site_id = course_id
     @driver = Utils.launch_browser
     @canvas = Page::CanvasPage.new @driver
     @cal_net = Page::CalNetPage.new @driver
@@ -22,11 +23,12 @@ describe 'Canvas assignment sync', order: :defined do
     @assignment_1 = Assignment.new("Submission Assignment 1 #{test_id}", nil)
     @assignment_2 = Assignment.new("Submission Assignment 2 #{test_id}", nil)
 
-    # Create course site if necessary
+    # Create course site if necessary. If an existing site, ensure Canvas sync is enabled.
     @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
     @canvas.get_suite_c_test_course(@course, [@teacher, @student], test_id, [SuiteCTools::ASSET_LIBRARY, SuiteCTools::ENGAGEMENT_INDEX])
     @asset_library_url = @canvas.click_tool_link(@driver, SuiteCTools::ASSET_LIBRARY)
     @engagement_index_url = @canvas.click_tool_link(@driver, SuiteCTools::ENGAGEMENT_INDEX)
+    @asset_library.ensure_canvas_sync(@driver, @asset_library_url) unless course_id.nil?
 
     @asset_1 = Asset.new @student.assets[0]
     @asset_1.title = @asset_library.get_canvas_submission_title @asset_1


### PR DESCRIPTION
Changes:

- Check that the _suitec file folder is hidden
- Handle course sites where Canvas sync is disabled
- Verify that users removed from course sites lose access to tools as expected

In a couple of scripts, variable declarations had to be moved out of 'before' hooks to make them accessible to other 'describe' blocks.  This accounts for most of the changed lines.