### PR TITLE
Reduce test execution time, fix minor problems handling UI

### DIFF
--- a/pages/cal_net_page.rb
+++ b/pages/cal_net_page.rb
@@ -28,7 +28,7 @@ module Page
       # If no credentials are available, then wait for manual login
       if username == 'secret' || password == 'secret'
         logger.debug 'Waiting for manual login'
-        wait_for_element_and_type_js(username_element, 'PLEASE LOG IN MANUALLY')
+        wait_for_element_and_type(username_element, 'PLEASE LOG IN MANUALLY')
         username_element.flash
         sign_in_button_element.when_not_present Utils.long_wait
       else

--- a/pages/canvas_page.rb
+++ b/pages/canvas_page.rb
@@ -180,7 +180,7 @@ module Page
       wait_until(Utils.medium_wait) do
         scroll_to_bottom
         sleep 1
-        cell_element(xpath: "//tr[contains(@id,'#{user.canvas_id}')]").when_present Utils.short_wait
+        cell_element(xpath: "//tr[contains(@id,'#{user.canvas_id}')]").exists?
       end
     end
 
@@ -342,7 +342,7 @@ module Page
     def create_generic_course_site(driver, sub_account, course, test_users, test_id, tools = nil)
       if course.site_id.nil?
         load_sub_account sub_account
-        wait_for_load_and_click_js add_new_course_button_element
+        wait_for_load_and_click add_new_course_button_element
         course_name_input_element.when_visible Utils.short_wait
         course.title = "QA Test - #{test_id}" if course.title.nil?
         course.code = "QA #{test_id} LEC001" if course.code.nil?

--- a/pages/junction/canvas_create_course_site_page.rb
+++ b/pages/junction/canvas_create_course_site_page.rb
@@ -89,7 +89,7 @@ module Page
       # @param course [Course]
       def toggle_course_sections(course)
         button = button_element(xpath: "//button[contains(@aria-label,'#{course.title}')]")
-        wait_for_update_and_click_js button
+        wait_for_update_and_click button
       end
 
       # Given a section ID, returns a hash of section data displayed on that row

--- a/pages/suitec/asset_library_page.rb
+++ b/pages/suitec/asset_library_page.rb
@@ -78,13 +78,17 @@ module Page
         list_view_asset_link_elements.map { |link| link.attribute('href').sub("#{Utils.suite_c_base_url}/assetlibrary/", '') }
       end
 
-      # Loads the list view and waits for a given asset to appear
+      # Loads the list view and scrolls down until a given asset appears
       # @param driver [Selenium::WebDriver]
       # @param url [String]
       # @param asset [Asset]
       def load_list_view_asset(driver, url, asset)
         load_page(driver, url)
-        link_element(xpath: "//a[contains(@href,'/assetlibrary/#{asset.id}')]").when_present Utils.medium_wait
+        wait_until(Utils.medium_wait) do
+          scroll_to_bottom
+          sleep 1
+          link_element(xpath: "//a[contains(@href,'/assetlibrary/#{asset.id}')]").exists?
+        end
       end
 
       # Given the index of an asset in list view, returns the asset's view count
@@ -508,7 +512,7 @@ module Page
 
       # DOWNLOAD
 
-      link(:download_asset_link, xpath: '//a[contains(.,"Download asset")]')
+      link(:download_asset_link, xpath: '//a[contains(.,"Download")]')
 
       # Prepares the download directory, clicks an asset's download button, and waits for the expected file to appear in the
       # directory
@@ -516,7 +520,7 @@ module Page
       def download_asset(asset)
         logger.info 'Downloading original asset'
         Utils.prepare_download_dir
-        wait_for_load_and_click_js download_asset_link_element
+        wait_for_load_and_click download_asset_link_element
         download_file_path = "#{Utils.download_dir}/*#{asset.file_name}"
         wait_until(Utils.long_wait) { Dir[download_file_path].any? }
       end

--- a/pages/suitec/whiteboards_page.rb
+++ b/pages/suitec/whiteboards_page.rb
@@ -165,8 +165,8 @@ module Page
       # @param user [User]
       def add_collaborator(user)
         click_settings_button
-        wait_for_update_and_click_js collaborator_list_element
-        wait_for_update_and_click_js collaborator_option_link(user)
+        wait_for_update_and_click collaborator_list_element
+        wait_for_update_and_click collaborator_option_link(user)
         wait_until(Utils.short_wait) { collaborator_name user }
         wait_for_update_and_click edit_title_input_element
         wait_for_update_and_click save_edit_element

--- a/spec/junction/canvas_lti_rosters_spec.rb
+++ b/spec/junction/canvas_lti_rosters_spec.rb
@@ -108,6 +108,7 @@ describe 'bCourses Roster Photos' do
 
     it "shows UID #{teacher_1.uid} actual photos for enrolled students on #{course.code} course site ID #{course.site_id}" do
       @roster_photos_page.wait_until(Utils.medium_wait) { @roster_photos_page.roster_photo_elements.length <= @student_count }
+      expect(@roster_photos_page.roster_photo_elements.any?).to be true
     end
 
     it "shows UID #{teacher_1.uid} placeholder photos for waitlisted students on #{course.code} course site ID #{course.site_id}" do

--- a/spec/suitec/asset_library_content_spec.rb
+++ b/spec/suitec/asset_library_content_spec.rb
@@ -17,109 +17,72 @@ describe 'New asset uploads', order: :defined do
     @canvas = Page::CanvasPage.new @driver
     @cal_net = Page::CalNetPage.new @driver
     @asset_library = Page::SuiteCPages::AssetLibraryPage.new @driver
-    @engagement_index = Page::SuiteCPages::EngagementIndexPage.new @driver
 
     @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
-    @canvas.create_generic_course_site(@driver, Utils.canvas_qa_sub_account, @course, users, Utils.get_test_id, [SuiteCTools::ASSET_LIBRARY, SuiteCTools::ENGAGEMENT_INDEX])
+    @canvas.create_generic_course_site(@driver, Utils.canvas_qa_sub_account, @course, users, Utils.get_test_id, [SuiteCTools::ASSET_LIBRARY])
 
     @canvas.load_course_site(@driver, @course)
     @asset_library_url = @canvas.click_tool_link(@driver, SuiteCTools::ASSET_LIBRARY)
-    @engagement_index_url = @canvas.click_tool_link(@driver, SuiteCTools::ENGAGEMENT_INDEX)
 
     users.each do |user|
 
       begin
+        @canvas.masquerade_as(@driver, user, @course)
         user_full_name = user.full_name
         user.assets.each do |asset|
 
           begin
-            @engagement_index.load_scores(@driver, @engagement_index_url)
-            @engagement_index.search_for_user user
-            initial_score = (@engagement_index.user_score user).to_i
-
             @asset = Asset.new asset
             asset_title = @asset.title
             asset_preview_type = @asset.preview
             @asset.description = nil
             @asset.category = nil
             @asset_size = File.size(Utils.test_data_file_path(@asset.file_name)).to_f / 1024000
+            @asset_library.load_page(@driver, @asset_library_url)
 
-            @canvas.masquerade_as(@driver, user, @course)
+            if @asset.type == 'File'
+              asset_file_name = @asset.file_name
 
-            begin
-              @asset_library.load_page(@driver, @asset_library_url)
+              # Excessively large files should be rejected
+              if @asset_size > 12
 
-              if @asset.type == 'File'
-                asset_file_name = @asset.file_name
+                @asset_library.click_upload_file_link
+                @asset_library.enter_file_path_for_upload @asset.file_name
+                asset_rejected = @asset_library.verify_block { @asset_library.upload_error_element.when_visible timeout }
 
-                # Excessively large files should be rejected
-                if @asset_size > 12
-
-                  @asset_library.click_upload_file_link
-                  @asset_library.enter_file_path_for_upload @asset.file_name
-                  asset_rejected = @asset_library.verify_block { @asset_library.upload_error_element.when_visible timeout }
-
-                  it("does not permit files over 10MB to be uploaded to the Asset Library for #{user_full_name} uploading #{asset_title}") { expect(asset_rejected).to be true }
-
-                else
-
-                  @asset_library.upload_file_to_library @asset
-                  @asset_library.wait_until(Utils.long_wait) { @asset_library.list_view_asset_elements.any? }
-                  file_uploaded = @asset_library.verify_block { @asset_library.verify_first_asset(user, @asset) }
-                  preview_generated = @asset_library.preview_generated?(@driver, @asset_library_url, @asset)
-                  asset_downloadable = @asset_library.verify_block { @asset_library.download_asset @asset }
-
-                  it("appear in the Asset Library for #{user_full_name} uploading #{asset_title}") { expect(file_uploaded).to be true }
-                  it("generate a preview of type #{asset_preview_type} for #{user_full_name} uploading #{asset_file_name}") { expect(preview_generated).to be true }
-                  it("can be downloaded by #{user_full_name} from the #{asset_title} asset detail page") { expect(asset_downloadable).to be true }
-
-                end
-
-              elsif @asset.type == 'Link'
-                asset_url = @asset.url
-
-                @asset_library.add_site @asset
-                @asset_library.wait_until(timeout) { @asset_library.list_view_asset_elements.any? }
-                url_uploaded = @asset_library.verify_block { @asset_library.verify_first_asset(user, @asset) }
-                preview_generated = @asset_library.preview_generated?(@driver, @asset_library_url, @asset)
-                has_download_button = @asset_library.download_asset_link?
-
-                it("appear in the Asset Library for #{user_full_name} uploading #{asset_title}") { expect(url_uploaded).to be true }
-                it("generate a preview of type #{asset_preview_type} for #{user_full_name} adding link #{asset_url}") { expect(preview_generated).to be true }
-                it("cannot be downloaded by #{user_full_name} from the #{asset_title} detail page") { expect(has_download_button).to be false }
+                it("do not permit files over 10MB to be uploaded to the Asset Library for #{user_full_name} uploading #{asset_title}") { expect(asset_rejected).to be true }
 
               else
 
-                it("could not process an invalid asset type '#{asset_title}' for #{user_full_name}") { fail }
+                @asset_library.upload_file_to_library @asset
+                @asset_library.wait_until(Utils.long_wait) { @asset_library.list_view_asset_elements.any? }
+                file_uploaded = @asset_library.verify_block { @asset_library.verify_first_asset(user, @asset) }
+                preview_generated = @asset_library.preview_generated?(@driver, @asset_library_url, @asset)
+                asset_downloadable = @asset_library.verify_block { @asset_library.download_asset @asset }
+
+                it("appear in the Asset Library for #{user_full_name} uploading #{asset_title}") { expect(file_uploaded).to be true }
+                it("generate a preview of type #{asset_preview_type} for #{user_full_name} uploading #{asset_file_name}") { expect(preview_generated).to be true }
+                it("can be downloaded by #{user_full_name} from the #{asset_title} asset detail page") { expect(asset_downloadable).to be true }
 
               end
-            rescue => e
-              logger.error "#{e.message + "\n"} #{e.backtrace.join("\n ")}"
-              it("caused an error with #{user_full_name}'s asset '#{asset_title}'") { fail }
-            ensure
-              @canvas.stop_masquerading @driver
-            end
 
-            unless @asset.type == 'File' && @asset_size > 12
-              @engagement_index.load_scores(@driver, @engagement_index_url)
-              @engagement_index.search_for_user user
-              current_score = @engagement_index.user_score user
+            elsif @asset.type == 'Link'
+              asset_url = @asset.url
 
-              it "earn 'Add a new asset to the Asset Library' points on the Engagement Index for #{user_full_name}" do
-                expect(current_score).to eql((initial_score + Activities::ADD_ASSET_TO_LIBRARY.points).to_s)
-              end
-            end
+              @asset_library.add_site @asset
+              @asset_library.wait_until(timeout) { @asset_library.list_view_asset_elements.any? }
+              url_uploaded = @asset_library.verify_block { @asset_library.verify_first_asset(user, @asset) }
+              preview_generated = @asset_library.preview_generated?(@driver, @asset_library_url, @asset)
+              has_download_button = @asset_library.download_asset_link?
 
-            scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
+              it("appear in the Asset Library for #{user_full_name} uploading #{asset_title}") { expect(url_uploaded).to be true }
+              it("generate a preview of type #{asset_preview_type} for #{user_full_name} adding link #{asset_url}") { expect(preview_generated).to be true }
+              it("cannot be downloaded by #{user_full_name} from the #{asset_title} detail page") { expect(has_download_button).to be false }
 
-            if @asset.type == 'File' && @asset_size > 12
-              it "add no 'add_asset' activity to the CSV export when #{user_full_name} uploads #{asset_title}" do
-                expect(scores).not_to include("#{user_full_name}, add_asset, #{Activities::ADD_ASSET_TO_LIBRARY.points}, #{initial_score + Activities::ADD_ASSET_TO_LIBRARY.points}")
-              end
             else
-              it "add 'add_asset' activity to the CSV export when #{user_full_name} uploads #{asset_title}" do
-                expect(scores).to include("#{user_full_name}, add_asset, #{Activities::ADD_ASSET_TO_LIBRARY.points}, #{initial_score + Activities::ADD_ASSET_TO_LIBRARY.points}")
-              end
+
+              it("could not process an invalid asset type '#{asset_title}' for #{user_full_name}") { fail }
+
             end
 
           rescue => e
@@ -133,6 +96,8 @@ describe 'New asset uploads', order: :defined do
         # Catch and report errors related to the user
         logger.error "#{e.message + "\n"} #{e.backtrace.join("\n ")}"
         it("caused an unexpected error for #{user_full_name}") { fail }
+      ensure
+        @canvas.stop_masquerading @driver
       end
     end
 

--- a/spec/suitec/asset_library_uploads_spec.rb
+++ b/spec/suitec/asset_library_uploads_spec.rb
@@ -19,16 +19,22 @@ describe 'Asset library file uploads', order: :defined do
     @canvas = Page::SuiteCPages::CanvasPage.new @driver
     @cal_net= Page::CalNetPage.new @driver
     @asset_library = Page::SuiteCPages::AssetLibraryPage.new @driver
+    @engagement_index = Page::SuiteCPages::EngagementIndexPage.new @driver
 
     @canvas.log_in(@cal_net, Utils.ets_qa_username, Utils.ets_qa_password)
-    @canvas.create_generic_course_site(@driver, Utils.canvas_qa_sub_account, @course, [@user], test_id, [SuiteCTools::ASSET_LIBRARY])
+    @canvas.create_generic_course_site(@driver, Utils.canvas_qa_sub_account, @course, [@user], test_id, [SuiteCTools::ASSET_LIBRARY, SuiteCTools::ENGAGEMENT_INDEX])
 
     @canvas.load_course_site(@driver, @course)
     @asset_library_url = @canvas.click_tool_link(@driver, SuiteCTools::ASSET_LIBRARY)
+    @engagement_index_url = @canvas.click_tool_link(@driver, SuiteCTools::ENGAGEMENT_INDEX)
 
     category_id = "#{Time.now.to_i}"
     @asset_library.add_custom_categories(@driver, @asset_library_url, [(@category_1="Category 1 - #{category_id}"), (@category_2="Category 2 - #{category_id}")])
     @asset_library.delete_custom_category @category_2
+
+    @engagement_index.load_scores(@driver, @engagement_index_url)
+    @engagement_index.search_for_user @user
+    @initial_score = @engagement_index.user_score(@user).to_i
     @canvas.log_out(@driver, @cal_net)
 
     @canvas.log_in(@cal_net, @user.username, Utils.test_user_password)
@@ -49,10 +55,23 @@ describe 'Asset library file uploads', order: :defined do
     @asset_library.verify_first_asset(@user, @asset)
   end
 
+  it 'earn "Add a new asset to the Asset Library" points on the Engagement Index' do
+    @engagement_index.load_scores(@driver, @engagement_index_url)
+    @engagement_index.search_for_user @user
+    current_score = @engagement_index.user_score @user
+    expect(current_score).to eql("#{@initial_score + Activities::ADD_ASSET_TO_LIBRARY.points}")
+  end
+
+  it 'add "add_asset" activity to the CSV export' do
+    scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
+    expect(scores).to include("#{@user.full_name}, add_asset, #{Activities::ADD_ASSET_TO_LIBRARY.points}, #{@initial_score + Activities::ADD_ASSET_TO_LIBRARY.points}")
+  end
+
   it 'can be added with title and category only' do
     @asset.title = @title
     @asset.description = nil
     @asset.category = @category_1
+    @asset_library.load_page(@driver, @asset_library_url)
     @asset_library.upload_file_to_library @asset
     @asset_library.wait_until(timeout) { @asset_library.list_view_asset_elements.any? }
     @asset_library.verify_first_asset(@user, @asset)

--- a/spec/suitec/canvas_assignment_sync_spec.rb
+++ b/spec/suitec/canvas_assignment_sync_spec.rb
@@ -110,6 +110,7 @@ describe 'Canvas assignment sync', order: :defined do
       @asset_library.click_manage_assets_link
       @asset_library.disable_assignment_sync @assignment_1
       @asset_library.enable_assignment_sync @assignment_2
+      @asset_library.pause_for_poller
     end
 
     it 'does not alter existing assignment submission points on the Engagement Index score' do

--- a/spec/suitec/engagement_index_points_config_spec.rb
+++ b/spec/suitec/engagement_index_points_config_spec.rb
@@ -18,7 +18,7 @@ describe 'Engagement Index points configuration', order: :defined do
     @asset_library = Page::SuiteCPages::AssetLibraryPage.new @driver
     @engagement_index = Page::SuiteCPages::EngagementIndexPage.new @driver
 
-    @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_username)
+    @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
     @canvas.create_generic_course_site(@driver, Utils.canvas_qa_sub_account, @course, [@teacher, @student],
                                        Utils.get_test_id, [SuiteCTools::ASSET_LIBRARY, SuiteCTools::ENGAGEMENT_INDEX])
 

--- a/spec/suitec/whiteboard_collaboration_spec.rb
+++ b/spec/suitec/whiteboard_collaboration_spec.rb
@@ -298,9 +298,7 @@ describe 'Whiteboard', order: :defined do
     it "allows #{student_1.full_name} to delete a member" do
       @whiteboards_driver_1.remove_collaborator student_3
       @whiteboards_driver_1.show_collaborators_pane
-      ("#{@driver_1.browser}" == 'chrome') ?
-          @whiteboards_driver_1.collaborator(student_3).when_not_present(timeout) :
-          @whiteboards_driver_1.collaborator(student_3).when_not_visible(timeout)
+      @whiteboards_driver_1.collaborator(student_3).when_not_visible timeout
     end
 
     it "allows #{student_1.full_name} to delete its own membership" do

--- a/spec/suitec/whiteboard_management_spec.rb
+++ b/spec/suitec/whiteboard_management_spec.rb
@@ -272,6 +272,8 @@ describe 'Whiteboard', order: :defined do
       @whiteboards.create_and_open_whiteboard(@driver, @whiteboard)
     end
 
+    after(:each) { @whiteboards.close_whiteboard @driver }
+
     it 'is not possible if the whiteboard has no assets' do
       @whiteboards.click_export_button
       @whiteboards.export_to_library_button_element.when_visible timeout
@@ -283,7 +285,7 @@ describe 'Whiteboard', order: :defined do
       @whiteboards.add_existing_assets @assets
       @whiteboards.open_original_asset_link_element.when_visible Utils.long_wait
       whiteboard_asset = @whiteboards.export_to_asset_library @whiteboard
-      @whiteboards.wait_until { @whiteboards.export_confirm_msg? }
+      @whiteboards.export_confirm_msg_element.when_present Utils.medium_wait
       @asset_library.load_page(@driver, @asset_library_url)
       @asset_library.verify_first_asset(@student_1, whiteboard_asset)
     end


### PR DESCRIPTION
- The looping "asset library content" script is mainly intended to verify handling of various asset types (e.g., preview service), but it also checks activity points updates for each asset.  The latter means it performs the same test over and over again for every file and every URL.  The activity point test are now moved to scripts that perform the checks once only.
- Misc other tweaks to UI handling, including continuing reduction in use of JS for click()-ing.