### PR TITLE
Minor Junction test fixes

### DIFF
--- a/pages/page.rb
+++ b/pages/page.rb
@@ -43,7 +43,7 @@ module Page
   end
 
   def js_click(element)
-    execute_script('arguments[0].click();', element)
+    execute_script('arguments[0].click();', element) rescue click_element(element, Utils.short_wait)
   end
 
   # Awaits an element for a given timeout then clicks it using JavaScript.

--- a/spec/junction/canvas_lti_mailing_lists_spec.rb
+++ b/spec/junction/canvas_lti_mailing_lists_spec.rb
@@ -165,6 +165,8 @@ describe 'bCourses Mailgun mailing lists', order: :defined do
 
       it 'creates mailing list memberships for users who have been restored to the site' do
         @canvas_page.add_users(course_site_1, [students[0]])
+        @canvas_page.masquerade_as(@driver, students[0], course_site_1)
+        @canvas_page.stop_masquerading @driver
         Utils.clear_cache(@driver, @splash_page, @toolbox_page)
         @mailing_lists_page.load_embedded_tool @driver
         @mailing_lists_page.search_for_list course_site_1.site_id


### PR DESCRIPTION
Two changes:
- If clicking via JS fails, then try a WebDriver click
- "Pending" users won't be added to a mailing list, so make sure test users accept the course invite