### PR TITLE
Speed up test execution

### DIFF
--- a/pages/page.rb
+++ b/pages/page.rb
@@ -48,7 +48,7 @@ module Page
       element.when_present Utils.short_wait
       execute_script('arguments[0].click();', element)
     rescue Selenium::WebDriver::Error::UnknownError
-      retry unless (tries -= 1).zero?
+      (tries -= 1).zero? ? fail : retry
     end
   end
 

--- a/pages/suitec/asset_library_page.rb
+++ b/pages/suitec/asset_library_page.rb
@@ -107,7 +107,10 @@ module Page
       # @param url [String]
       # @param asset [Asset]
       def load_asset_detail(driver, url, asset)
+        # TODO - remove the following line when asset deep links work from the Asset Library
+        navigate_to 'http://www.google.com'
         navigate_to "#{url}#col_asset=#{asset.id}"
+        switch_to_canvas_iframe driver
         wait_for_asset_detail asset
       end
 

--- a/pages/suitec/suite_c_pages.rb
+++ b/pages/suitec/suite_c_pages.rb
@@ -105,7 +105,7 @@ module Page
     def upload_file_to_library(asset)
       click_upload_file_link
       enter_and_upload_file asset
-      asset.id = list_view_asset_ids.first
+      logger.info "Asset ID is #{asset.id = list_view_asset_ids.first}"
     end
 
     # Uses JavaScript to make the file upload input visible, then enters the file to be uploaded
@@ -157,7 +157,7 @@ module Page
     def add_site(asset)
       click_add_site_link
       enter_and_submit_url asset
-      asset.id = list_view_asset_ids.first
+      logger.info "Asset ID is #{asset.id = list_view_asset_ids.first}"
     end
 
     # Enters asset metadata while adding a link type asset

--- a/spec/junction/canvas_lti_mailing_lists_spec.rb
+++ b/spec/junction/canvas_lti_mailing_lists_spec.rb
@@ -155,7 +155,7 @@ describe 'bCourses Mailgun mailing lists', order: :defined do
       end
 
       it 'deletes mailing list memberships for users who have been removed from the site' do
-        @canvas_page.remove_user_from_course(course_site_1, students[0])
+        @canvas_page.remove_users_from_course(course_site_1, [students[0]])
         Utils.clear_cache(@driver, @splash_page, @toolbox_page)
         @mailing_lists_page.load_embedded_tool @driver
         @mailing_lists_page.search_for_list course_site_1.site_id

--- a/spec/suitec/canvas_assignment_submissions_spec.rb
+++ b/spec/suitec/canvas_assignment_submissions_spec.rb
@@ -35,10 +35,12 @@ describe 'Canvas assignment submission', order: :defined do
     @canvas.masquerade_as(@driver, @teacher, @course)
     @canvas.create_assignment(@course, @assignment)
 
-    # Enable Canvas assignment sync
+    # Enable Canvas assignment sync, then create another assignment. When the latter appears as a category, the former should have sync enabled.
     @asset_library.wait_for_canvas_category(@driver, @asset_library_url, @assignment)
     @asset_library.enable_assignment_sync @assignment
-    @asset_library.pause_for_poller
+    poller_assignment = Assignment.new("Throwaway Assignment #{test_id}", nil)
+    @canvas.create_assignment(@course, poller_assignment)
+    @asset_library.wait_for_canvas_category(@driver, @asset_library_url, poller_assignment)
     @canvas.stop_masquerading @driver
 
     # Submit assignment

--- a/spec/suitec/canvas_assignment_sync_spec.rb
+++ b/spec/suitec/canvas_assignment_sync_spec.rb
@@ -68,7 +68,9 @@ describe 'Canvas assignment sync', order: :defined do
       @asset_library.load_page(@driver, @asset_library_url)
       @asset_library.click_manage_assets_link
       @asset_library.enable_assignment_sync @assignment_1
-      @asset_library.pause_for_poller
+      poller_assignment = Assignment.new("Throwaway Assignment 1 #{test_id}", nil)
+      @canvas.create_assignment(@course, poller_assignment)
+      @asset_library.wait_for_canvas_category(@driver, @asset_library_url, poller_assignment)
 
       # Student submits both assignments
       @canvas.masquerade_as(@driver, @student, @course)
@@ -118,7 +120,9 @@ describe 'Canvas assignment sync', order: :defined do
       @asset_library.click_manage_assets_link
       @asset_library.disable_assignment_sync @assignment_1
       @asset_library.enable_assignment_sync @assignment_2
-      @asset_library.pause_for_poller
+      poller_assignment = Assignment.new("Throwaway Assignment 2 #{test_id}", nil)
+      @canvas.create_assignment(@course, poller_assignment)
+      @asset_library.wait_for_canvas_category(@driver, @asset_library_url, poller_assignment)
     end
 
     it 'does not alter existing assignment submission points on the Engagement Index score' do
@@ -155,6 +159,8 @@ describe 'Canvas assignment sync', order: :defined do
     end
 
     it 'deletes the Assignment 1 submission files from the Files system' do
+      # Wait a bit for the files to be deleted
+      sleep Utils.medium_wait
       @canvas.search_for_file(@course, asset_1_canvas_file_name)
       @canvas.paragraph_element(xpath: '//p[contains(.,"did not match any files")]').when_present Utils.medium_wait
     end

--- a/spec/suitec/canvas_discussions_spec.rb
+++ b/spec/suitec/canvas_discussions_spec.rb
@@ -6,6 +6,10 @@ describe 'A Canvas discussion', order: :defined do
   test_id = Utils.get_test_id
   test_user_data = Utils.load_test_users.select { |data| data['tests']['canvasDiscussions'] }
 
+  add_topic = Activity::ADD_DISCUSSION_TOPIC
+  add_entry = Activity::ADD_DISCUSSION_ENTRY
+  get_reply = Activity::GET_DISCUSSION_REPLY
+
   before(:all) do
     @course = Course.new({})
     @course.site_id = course_id
@@ -29,88 +33,51 @@ describe 'A Canvas discussion', order: :defined do
       @asset_library.ensure_canvas_sync(@driver, @asset_library_url)
     end
 
-    # Determine expected scores
+    # Get current score
     @engagement_index.load_scores(@driver, @engagement_index_url)
     @user_1_score = @engagement_index.user_score @user_1
-    @user_1_expected_score = (@user_1_score.to_i + Activity::ADD_DISCUSSION_TOPIC.points).to_s
 
-    # User 1 creates a discussion topic
+    # User 1 creates a discussion topic, which should earn points
     @discussion = Discussion.new "Discussion Topic #{test_id}"
     @canvas.log_out(@driver, @cal_net)
     @canvas.log_in(@cal_net, @user_1.username, Utils.test_user_password)
     @canvas.create_course_discussion(@driver, @course, @discussion)
+    @user_1_expected_score = "#{@user_1_score.to_i + add_topic.points}"
   end
 
   after(:all) { @driver.quit }
 
-  it "earns '#{Activity::ADD_DISCUSSION_TOPIC.title}' Engagement Index points for the discussion creator" do
+  it "earns '#{add_topic.title}' Engagement Index points for the discussion creator" do
     expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
   end
 
-  it "adds '#{Activity::ADD_DISCUSSION_TOPIC.type}' activity to the CSV export for the discussion creator" do
+  it "adds '#{add_topic.type}' activity to the CSV export for the discussion creator" do
     scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-    expect(scores).to include("#{@user_1.full_name}, #{Activity::ADD_DISCUSSION_TOPIC.type}, #{Activity::ADD_DISCUSSION_TOPIC.points}, #{@user_1_expected_score}")
+    expect(scores).to include("#{@user_1.full_name}, #{add_topic.type}, #{add_topic.points}, #{@user_1_expected_score}")
   end
 
   describe 'entry' do
 
     before(:all) do
-      # Determine expected scores
+      # Get current scores
       @engagement_index.load_page(@driver, @engagement_index_url)
       @user_1_score = @engagement_index.user_score @user_1
       @user_2_score = @engagement_index.user_score @user_2
-      @user_2_expected_score = (@user_2_score.to_i + Activity::ADD_DISCUSSION_ENTRY.points).to_s
 
-      # User 1 creates an entry on the topic
+      # User 1 creates an entry on the topic, which should earn no points
       @canvas.add_reply(@discussion, nil, 'Discussion entry by the discussion topic creator')
 
-      # User 2 creates an entry on the topic
+      # User 2 creates an entry on the topic, which should earn points for User 2 only
       @canvas.log_out(@driver, @cal_net)
       @canvas.log_in(@cal_net, @user_2.username, Utils.test_user_password)
       @canvas.load_course_site(@driver, @course)
-      @canvas.add_reply(@discussion, nil, 'Discussion entry by somebody other than the discussion topic creator')
+      @canvas.add_reply(@discussion, nil, 'Discussion entry by someone other than the discussion topic creator')
+      @user_2_expected_score = "#{@user_2_score.to_i + add_entry.points}"
     end
 
     context 'when added by someone other than the discussion topic creator' do
 
-      it "earns '#{Activity::ADD_DISCUSSION_ENTRY.title}' Engagement Index points for the user adding the entry" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
-      end
-
-      it('earns no points for the discussion topic creator') { expect(@engagement_index.user_score @user_1).to eql(@user_1_expected_score) }
-
-      it 'adds "discussion_entry" activity to the CSV export for the user adding the entry' do
-        scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@user_2.full_name}, #{Activity::ADD_DISCUSSION_ENTRY.type}, #{Activity::ADD_DISCUSSION_ENTRY.points}, #{@user_2_expected_score}")
-      end
-    end
-
-    context 'when added by the discussion topic creator' do
-
-      it "earns no '#{Activity::ADD_DISCUSSION_ENTRY.title}' Engagement Index points for the user adding the entry" do
-        expect(@engagement_index.user_score @user_1).to eql(@user_1_score)
-      end
-
-      it "adds no '#{Activity::ADD_DISCUSSION_ENTRY.type}' activity to the CSV export for the discussion creator" do
-        scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).not_to include("#{@user_1.full_name}, #{Activity::ADD_DISCUSSION_ENTRY.type}, #{Activity::ADD_DISCUSSION_ENTRY.points}, #{@user_1_score}")
-      end
-    end
-
-    context 'when added by someone who has already added an earlier discussion entry' do
-
-      before(:all) do
-        # Determine expected scores
-        @engagement_index.load_page(@driver, @engagement_index_url)
-        @user_1_score = @engagement_index.user_score @user_1
-        @user_2_score = @engagement_index.user_score @user_2
-        @user_2_expected_score = (@user_2_expected_score.to_i + Activity::ADD_DISCUSSION_ENTRY.points).to_s
-
-        # User 2 replies to the topic again
-        @canvas.add_reply(@discussion, nil, 'Discussion entry by somebody other than the discussion topic creator')
-      end
-
-      it "earns '#{Activity::ADD_DISCUSSION_ENTRY.title}' Engagement Index points for the user adding the entry" do
+      it "earns '#{add_entry.title}' Engagement Index points for the user adding the entry" do
         expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
       end
 
@@ -118,202 +85,232 @@ describe 'A Canvas discussion', order: :defined do
 
       it 'adds "discussion_entry" activity to the CSV export for the user adding the entry' do
         scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@user_2.full_name}, #{Activity::ADD_DISCUSSION_ENTRY.type}, #{Activity::ADD_DISCUSSION_ENTRY.points}, #{@user_2_expected_score}")
+        expect(scores).to include("#{@user_2.full_name}, #{add_entry.type}, #{add_entry.points}, #{@user_2_expected_score}")
+      end
+    end
+
+    context 'when added by the discussion topic creator' do
+
+      it("earns no '#{add_entry.title}' Engagement Index points for the user adding the entry") { expect(@engagement_index.user_score @user_1).to eql(@user_1_score) }
+
+      it "adds no '#{add_entry.type}' activity to the CSV export for the discussion creator" do
+        scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
+        expect(scores).not_to include("#{@user_1.full_name}, #{add_entry.type}, #{add_entry.points}, #{@user_1_score.to_i + add_entry.points}")
+      end
+    end
+
+    context 'when added by someone who has already added an earlier discussion entry' do
+
+      before(:all) do
+        # Get current scores
+        @engagement_index.load_page(@driver, @engagement_index_url)
+        @user_1_score = @engagement_index.user_score @user_1
+        @user_2_score = @engagement_index.user_score @user_2
+
+        # User 2 replies to the topic again, which should earn points for User 2 only
+        @canvas.add_reply(@discussion, nil, 'Discussion entry by somebody other than the discussion topic creator')
+        @user_2_expected_score = "#{@user_2_expected_score.to_i + add_entry.points}"
+      end
+
+      it "earns '#{add_entry.title}' Engagement Index points for the user adding the entry" do
+        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
+      end
+
+      it('earns no points for the discussion topic creator') { expect(@engagement_index.user_score @user_1).to eql(@user_1_score) }
+
+      it 'adds "discussion_entry" activity to the CSV export for the user adding the entry' do
+        scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
+        expect(scores).to include("#{@user_2.full_name}, #{add_entry.type}, #{add_entry.points}, #{@user_2_expected_score}")
       end
     end
   end
 
   describe 'entry reply' do
 
-    context 'when added by someone who created the discussion topic but not the discussion entry' do
+    context 'when added by someone' do
 
       before(:all) do
-        # Determine expected scores
+        # Get current scores
         @engagement_index.load_page(@driver, @engagement_index_url)
         @user_1_score = @engagement_index.user_score @user_1
         @user_2_score = @engagement_index.user_score @user_2
-        @user_1_expected_score = (@user_1_score.to_i + Activity::ADD_DISCUSSION_ENTRY.points).to_s
-        @user_2_expected_score = (@user_2_score.to_i + Activity::GET_DISCUSSION_REPLY.points).to_s
 
-        # User 1 replies to User 2's first entry
-        @canvas.log_out(@driver, @cal_net)
-        @canvas.log_in(@cal_net, @user_1.username, Utils.test_user_password)
-        @canvas.add_reply(@discussion, 1, 'Reply by the discussion topic creator but not the discussion entry creator')
-      end
-
-      it "earns '#{Activity::ADD_DISCUSSION_ENTRY.title}' Engagement Index points for the user who added the discussion entry reply" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
-      end
-
-      it "earns '#{Activity::GET_DISCUSSION_REPLY.title}' Engagement Index points for the user who received the discussion entry reply" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
-      end
-
-      it "adds '#{Activity::ADD_DISCUSSION_ENTRY.title}' and '#{Activity::GET_DISCUSSION_REPLY.type}' activity to the CSV export for the users" do
-        scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@user_1.full_name}, #{Activity::ADD_DISCUSSION_ENTRY.type}, #{Activity::ADD_DISCUSSION_ENTRY.points}, #{@user_1_expected_score}")
-        expect(scores).to include("#{@user_2.full_name}, #{Activity::GET_DISCUSSION_REPLY.type}, #{Activity::GET_DISCUSSION_REPLY.points}, #{@user_2_expected_score}")
-      end
-    end
-
-    context 'when added by someone who did not create the discussion topic or the discussion entry' do
-
-      before(:all) do
-        # Determine expected scores
-        @engagement_index.load_page(@driver, @engagement_index_url)
-        @user_1_score = @engagement_index.user_score @user_1
-        @user_2_score = @engagement_index.user_score @user_2
-        @user_1_expected_score = (@user_1_score.to_i + Activity::GET_DISCUSSION_REPLY.points).to_s
-        @user_2_expected_score = (@user_2_score.to_i + Activity::ADD_DISCUSSION_ENTRY.points).to_s
-
-        # User 2 replies to User 1's entry
-        @canvas.log_out(@driver, @cal_net)
-        @canvas.log_in(@cal_net, @user_2.username, Utils.test_user_password)
-        @canvas.add_reply(@discussion, 0, 'Reply by somebody other than the discussion topic creator and other than the discussion entry creator')
-      end
-
-      it "earns '#{Activity::GET_DISCUSSION_REPLY.title}' Engagement Index points for the user who received the discussion entry reply" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
-      end
-
-      it "earns '#{Activity::ADD_DISCUSSION_ENTRY.title}' Engagement Index points for the user who added the discussion entry reply" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
-      end
-
-      it "adds '#{Activity::ADD_DISCUSSION_ENTRY.title}' and '#{Activity::GET_DISCUSSION_REPLY.type}' activity to the CSV export for the users" do
-        scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@user_1.full_name}, #{Activity::GET_DISCUSSION_REPLY.type}, #{Activity::GET_DISCUSSION_REPLY.points}, #{@user_1_expected_score}")
-        expect(scores).to include("#{@user_2.full_name}, #{Activity::ADD_DISCUSSION_ENTRY.type}, #{Activity::ADD_DISCUSSION_ENTRY.points}, #{@user_2_expected_score}")
-      end
-    end
-
-    context 'when added by someone who created the discussion topic and the discussion entry' do
-
-      before(:all) do
-        # Expect no change in score
-        @engagement_index.load_page(@driver, @engagement_index_url)
-        @user_1_score = @engagement_index.user_score @user_1
-
-        # User 1 replies to own entry
+        # User 1 replies to own entry, which should earn no points
         @canvas.log_out(@driver, @cal_net)
         @canvas.log_in(@cal_net, @user_1.username, Utils.test_user_password)
         @canvas.add_reply(@discussion, 0, 'Reply by the discussion topic creator and also the discussion entry creator')
 
-        # Wait for poller to complete a cycle before verifying no score change
-        @engagement_index.pause_for_poller
-        @engagement_index.load_page(@driver, @engagement_index_url)
+        # User 1 replies to User 2's first entry, which should earn points for both
+        @canvas.log_out(@driver, @cal_net)
+        @canvas.log_in(@cal_net, @user_1.username, Utils.test_user_password)
+        @canvas.add_reply(@discussion, 2, 'Reply by the discussion topic creator but not the discussion entry creator')
+        @user_1_expected_score = "#{@user_1_score.to_i + add_entry.points}"
+        @user_2_expected_score = "#{@user_2_score.to_i + get_reply.points}"
       end
 
-      it('earns no Engagement Index points for the user') { expect(@engagement_index.user_score @user_1).to eql(@user_1_score) }
+      context 'who created the discussion topic but not the discussion entry' do
+
+        it "earns '#{add_entry.title}' Engagement Index points for the user who added the discussion entry reply" do
+          expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
+        end
+
+        it "earns '#{get_reply.title}' Engagement Index points for the user who received the discussion entry reply" do
+          expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
+        end
+
+        it "adds '#{add_entry.title}' and '#{get_reply.type}' activity to the CSV export for the users" do
+          scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
+          expect(scores).to include("#{@user_1.full_name}, #{add_entry.type}, #{add_entry.points}, #{@user_1_expected_score}")
+          expect(scores).to include("#{@user_2.full_name}, #{get_reply.type}, #{get_reply.points}, #{@user_2_expected_score}")
+        end
+      end
+
+      context 'when added by someone who created the discussion topic and the discussion entry' do
+
+        it('earns no Engagement Index points for the user') { expect(@engagement_index.user_score @user_1).to eql(@user_1_expected_score) }
+
+      end
+    end
+
+    context 'when added by someone' do
+
+      before(:all) do
+        # Get current scores
+        @engagement_index.load_page(@driver, @engagement_index_url)
+        @user_1_score = @engagement_index.user_score @user_1
+        @user_2_score = @engagement_index.user_score @user_2
+
+        # User 2 replies to own first entry, which should earn no points
+        @canvas.log_out(@driver, @cal_net)
+        @canvas.log_in(@cal_net, @user_2.username, Utils.test_user_password)
+        @canvas.add_reply(@discussion, 2, 'Reply by somebody other than the discussion topic creator but who is the discussion entry creator')
+
+        # User 2 replies to User 1's entry, which should earn points for both
+        @canvas.log_out(@driver, @cal_net)
+        @canvas.log_in(@cal_net, @user_2.username, Utils.test_user_password)
+        @canvas.add_reply(@discussion, 0, 'Reply by somebody other than the discussion topic creator and other than the discussion entry creator')
+        @user_1_expected_score = "#{@user_1_score.to_i + get_reply.points}"
+        @user_2_expected_score = "#{@user_2_score.to_i + add_entry.points}"
+      end
+
+      context 'who did not create the discussion topic or the discussion entry' do
+
+        it "earns '#{get_reply.title}' Engagement Index points for the user who received the discussion entry reply" do
+          expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
+        end
+
+        it "earns '#{add_entry.title}' Engagement Index points for the user who added the discussion entry reply" do
+          expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
+        end
+
+        it "adds '#{add_entry.title}' and '#{get_reply.type}' activity to the CSV export for the users" do
+          scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
+          expect(scores).to include("#{@user_1.full_name}, #{get_reply.type}, #{get_reply.points}, #{@user_1_expected_score}")
+          expect(scores).to include("#{@user_2.full_name}, #{add_entry.type}, #{add_entry.points}, #{@user_2_expected_score}")
+        end
+      end
+
+      context 'who did not create the discussion topic but did create the discussion entry' do
+
+        it('earns no Engagement Index points for the user') { expect(@engagement_index.user_score @user_2).to eql(@user_2_expected_score) }
+
+      end
 
     end
 
-    context 'when added by someone who did not create the discussion topic but did create the discussion entry' do
+    context 'when added by someone' do
 
       before(:all) do
-        # Expect no change in score
+        # Get current scores
         @engagement_index.load_page(@driver, @engagement_index_url)
+        @user_1_score = @engagement_index.user_score @user_1
         @user_2_score = @engagement_index.user_score @user_2
 
-        # User 2 replies to own first entry
+        # User 2 replies to own first entry, which should earn no points
         @canvas.log_out(@driver, @cal_net)
         @canvas.log_in(@cal_net, @user_2.username, Utils.test_user_password)
         @canvas.add_reply(@discussion, 3, 'Reply by somebody other than the discussion topic creator but who is the discussion entry creator')
 
-        # Wait for poller to complete a cycle before verifying no score change
-        @engagement_index.pause_for_poller
-        @engagement_index.load_page(@driver, @engagement_index_url)
-      end
-
-      it('earns no Engagement Index points for the user') { expect(@engagement_index.user_score @user_2).to eql(@user_2_score) }
-
-    end
-
-    context 'when added by someone who has already added an earlier discussion entry reply' do
-
-      before(:all) do
-        # Determine expected scores
-        @engagement_index.load_page(@driver, @engagement_index_url)
-        @user_1_score = @engagement_index.user_score @user_1
-        @user_2_score = @engagement_index.user_score @user_2
-        @user_1_expected_score = (@user_1_score.to_i + Activity::GET_DISCUSSION_REPLY.points).to_s
-        @user_2_expected_score = (@user_2_score.to_i + Activity::ADD_DISCUSSION_ENTRY.points).to_s
-
-        # User 2 replies again to User 1's reply
+        # User 2 replies again to User 1's reply, which should earn points for both
         @canvas.log_out(@driver, @cal_net)
         @canvas.log_in(@cal_net, @user_2.username, Utils.test_user_password)
         @canvas.add_reply(@discussion, 0, 'Reply by somebody other than the discussion topic creator and other than the discussion entry creator')
-        @engagement_index.load_page(@driver, @engagement_index_url)
+        @user_1_expected_score = "#{@user_1_score.to_i + get_reply.points}"
+        @user_2_expected_score = "#{@user_2_score.to_i + add_entry.points}"
       end
 
-      it "earns '#{Activity::GET_DISCUSSION_REPLY.title}' Engagement Index points for the user who received the discussion entry reply" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
+      context 'who did not create the discussion topic but did create the discussion entry' do
+
+        it "earns '#{get_reply.title}' Engagement Index points for the user who received the discussion entry reply" do
+          expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
+        end
+
+        it "earns '#{add_entry.title}' Engagement Index points for the user who added the discussion entry reply" do
+          expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
+        end
+
+        it "adds '#{add_entry.title}' and '#{get_reply.type}' activity to the CSV export for the users" do
+          scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
+          expect(scores).to include("#{@user_1.full_name}, #{get_reply.type}, #{get_reply.points}, #{@user_1_expected_score}")
+          expect(scores).to include("#{@user_2.full_name}, #{add_entry.type}, #{add_entry.points}, #{@user_2_expected_score}")
+        end
       end
 
-      it "earns '#{Activity::ADD_DISCUSSION_ENTRY.title}' Engagement Index points for the user who added the discussion entry reply" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
-      end
+      context 'who added an earlier discussion entry reply' do
 
-      it "adds '#{Activity::ADD_DISCUSSION_ENTRY.title}' and '#{Activity::GET_DISCUSSION_REPLY.type}' activity to the CSV export for the users" do
-        scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@user_1.full_name}, #{Activity::GET_DISCUSSION_REPLY.type}, #{Activity::GET_DISCUSSION_REPLY.points}, #{@user_1_expected_score}")
-        expect(scores).to include("#{@user_2.full_name}, #{Activity::ADD_DISCUSSION_ENTRY.type}, #{Activity::ADD_DISCUSSION_ENTRY.points}, #{@user_2_expected_score}")
+        it('earns no Engagement Index points for the user') { expect(@engagement_index.user_score @user_2).to eql(@user_2_expected_score) }
+
       end
     end
   end
 
   describe 'reply to reply' do
 
-    context 'when added by someone who created the entry but not the reply' do
+    context 'when added by someone' do
 
       before(:all) do
-        # Determine expected scores
+        # Get current scores
         @engagement_index.load_page(@driver, @engagement_index_url)
         @user_1_score = @engagement_index.user_score @user_1
         @user_2_score = @engagement_index.user_score @user_2
-        @user_1_expected_score = (@user_1_score.to_i + Activity::ADD_DISCUSSION_ENTRY.points).to_s
-        @user_2_expected_score = (@user_2_score.to_i + Activity::GET_DISCUSSION_REPLY.points).to_s
 
-        # User 1 replies to User 2's first reply to User 1's entry
-        @canvas.log_out(@driver, @cal_net)
-        @canvas.log_in(@cal_net, @user_1.username, Utils.test_user_password)
-        @canvas.add_reply(@discussion, 1, 'Reply-to-reply by somebody who created the topic and the entry but not the reply')
-      end
-
-      it "earns '#{Activity::ADD_DISCUSSION_ENTRY.title}' Engagement Index points for the user who added the reply to reply" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
-      end
-
-      it "earns '#{Activity::GET_DISCUSSION_REPLY.title}' Engagement Index points for the user who received the reply to reply" do
-        expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
-      end
-
-      it "adds '#{Activity::ADD_DISCUSSION_ENTRY.title}' and '#{Activity::GET_DISCUSSION_REPLY.type}' activity to the CSV export for the users" do
-        scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
-        expect(scores).to include("#{@user_1.full_name}, #{Activity::ADD_DISCUSSION_ENTRY.type}, #{Activity::ADD_DISCUSSION_ENTRY.points}, #{@user_1_expected_score}")
-        expect(scores).to include("#{@user_2.full_name}, #{Activity::GET_DISCUSSION_REPLY.type}, #{Activity::GET_DISCUSSION_REPLY.points}, #{@user_2_expected_score}")
-      end
-    end
-
-    context 'when added by someone who created the reply but not the entry' do
-
-      before(:all) do
-        # Expect no change in score
-        @engagement_index.load_page(@driver, @engagement_index_url)
-        @user_2_score = @engagement_index.user_score @user_2
-
-        # User 2 replies to its own first reply to User 1's entry
+        # User 2 replies to its own first reply to User 1's entry, which should earn no points
         @canvas.log_out(@driver, @cal_net)
         @canvas.log_in(@cal_net, @user_2.username, Utils.test_user_password)
-        @canvas.add_reply(@discussion, 1, 'Reply-to-reply by somebody who created the reply but not the topic or the entry')
+        @canvas.add_reply(@discussion, 2, 'Reply-to-reply by somebody who created the reply but not the topic or the entry')
 
-        # Wait for poller to complete a cycle before verifying no score change
-        @engagement_index.pause_for_poller
-        @engagement_index.load_page(@driver, @engagement_index_url)
+        # User 1 replies to User 2's first reply to User 1's entry, which should earn points for both
+        @canvas.log_out(@driver, @cal_net)
+        @canvas.log_in(@cal_net, @user_1.username, Utils.test_user_password)
+        @canvas.add_reply(@discussion, 2, 'Reply-to-reply by somebody who created the topic and the entry but not the reply')
+
+        # Determine expected scores
+        @user_1_expected_score = "#{@user_1_score.to_i + add_entry.points}"
+        @user_2_expected_score = "#{@user_2_score.to_i + get_reply.points}"
       end
 
-      it('earns no Engagement Index points for the user') { expect(@engagement_index.user_score @user_2).to eql(@user_2_score) }
+      context 'who created the entry but not the reply' do
 
+        it "earns '#{add_entry.title}' Engagement Index points for the user who added the reply to reply" do
+          expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_1, @user_1_expected_score)).to be true
+        end
+
+        it "earns '#{get_reply.title}' Engagement Index points for the user who received the reply to reply" do
+          expect(@engagement_index.user_score_updated?(@driver, @engagement_index_url, @user_2, @user_2_expected_score)).to be true
+        end
+
+        it "adds '#{add_entry.title}' and '#{get_reply.type}' activity to the CSV export for the users" do
+          scores = @engagement_index.download_csv(@driver, @course, @engagement_index_url)
+          expect(scores).to include("#{@user_1.full_name}, #{add_entry.type}, #{add_entry.points}, #{@user_1_expected_score}")
+          expect(scores).to include("#{@user_2.full_name}, #{get_reply.type}, #{get_reply.points}, #{@user_2_expected_score}")
+        end
+      end
+
+      context 'who created the reply but not the entry' do
+
+        it('earns no Engagement Index points for the user') { expect(@engagement_index.user_score @user_2).to eql(@user_2_expected_score) }
+
+      end
     end
   end
 end

--- a/spec/suitec/engagement_index_spec.rb
+++ b/spec/suitec/engagement_index_spec.rb
@@ -222,7 +222,7 @@ describe 'The Engagement Index', order: :defined do
 
     before(:all) do
       @canvas.stop_masquerading @driver
-      [teacher, student_4].each { |user| @canvas.remove_user_from_course(@course, user) }
+      @canvas.remove_users_from_course(@course, [teacher, student_4])
     end
 
     [teacher, student_4].each do |user|

--- a/spec/suitec/whiteboard_collaboration_spec.rb
+++ b/spec/suitec/whiteboard_collaboration_spec.rb
@@ -318,7 +318,7 @@ describe 'Whiteboard', order: :defined do
 
     before(:all) do
       @canvas_driver_1.stop_masquerading @driver_1
-      [teacher, student_1].each { |user| @canvas_driver_1.remove_user_from_course(course, user) }
+      @canvas_driver_1.remove_users_from_course(course, [teacher, student_1])
       # Access to whiteboards is based on session cookie, so launch another browser to check cookie-less access
       @driver_3 = Utils.launch_browser
       @canvas_driver_3 = Page::CanvasPage.new @driver_3


### PR DESCRIPTION
Main changes:
- Since there was no way to know when the Canvas poller would sync a test course, many tests waited a generous and fixed amount of time before assuming the syncing had occurred.  Instead, the tests now perform an unrelated activity that should be picked up by the poller and be detectable in the SuiteC UI once updated.  That way, the test knows the poller has synced the course.
- Previously, users required by a test were added to a pre-existing course site even if they were already on the site.  Now, the tests don't bother re-adding the same users.
- The new Canvas UI requires some locator updates.
- The Canvas class has its methods rearranged into a more logical order.