### PR TITLE
More v2.3 test fixes

### DIFF
--- a/pages/canvas/canvas_activities_page.rb
+++ b/pages/canvas/canvas_activities_page.rb
@@ -148,8 +148,8 @@ module Page
     text_area(:assignment_due_date, class: 'DueDateInput')
     checkbox(:online_url_cbx, id: 'assignment_online_url')
     checkbox(:online_upload_cbx, id: 'assignment_online_upload')
-    checkbox(:text_entry_cbx, id: 'assignment_text_entry')
-
+    checkbox(:online_text_entry_cbx, id: 'assignment_text_entry')
+    checkbox(:online_media_cbx, id: 'assignment_media_recording')
     h1(:assignment_title_heading, class: 'title')
     link(:submit_assignment_link, text: 'Submit Assignment')
     link(:resubmit_assignment_link, text: 'Re-submit Assignment')
@@ -161,23 +161,48 @@ module Page
     button(:url_upload_submit_button, xpath: '(//button[@type="submit"])[2]')
     div(:assignment_submission_conf, xpath: '//div[contains(.,"Turned In!")]')
 
-    # Creates an assignment on a course site
+    # Begins creating a new assignment, entering title and scrolling to the submission types
     # @param course [Course]
     # @param assignment [Assignment]
-    def create_assignment(course, assignment)
-      logger.info "Creating submission assignment named '#{assignment.title}'"
+    def enter_new_assignment_title(course, assignment)
       navigate_to "#{Utils.canvas_base_url}/courses/#{course.site_id}/assignments/new"
       assignment_name_element.when_visible Utils.medium_wait
       assignment_name_element.send_keys assignment.title
       wait_for_element_and_type_js(assignment_due_date_element, assignment.due_date.strftime("%b %-d %Y")) unless assignment.due_date.nil?
       scroll_to_element assignment_type_element
       online_url_cbx_element.when_visible Utils.short_wait
-      check_online_url_cbx
-      check_online_upload_cbx
+    end
+
+    # Saves and publishes an assingment and returns its URL
+    # @param assignment [Assignment]
+    # @return [String]
+    def save_and_publish_assignment(assignment)
       click_save_and_publish
       published_button_element.when_visible Utils.medium_wait
       logger.info "Submission assignment URL is #{current_url}"
       assignment.url = current_url
+    end
+
+    # Creates a sync-able assignment on a course site
+    # @param course [Course]
+    # @param assignment [Assignment]
+    def create_assignment(course, assignment)
+      logger.info "Creating submission assignment named '#{assignment.title}'"
+      enter_new_assignment_title(course, assignment)
+      check_online_url_cbx
+      check_online_upload_cbx
+      save_and_publish_assignment assignment
+    end
+
+    # Creates a non-sync-able assignment on a course site
+    # @param course [Course]
+    # @param assignment [Assignment]
+    def create_unsyncable_assignment(course, assignment)
+      logger.info "Creating unsyncable assignment named '#{assignment.title}'"
+      enter_new_assignment_title(course, assignment)
+      check_online_text_entry_cbx
+      check_online_media_cbx
+      save_and_publish_assignment assignment
     end
 
     # Upload's a user's asset as an assignment submission

--- a/pages/canvas/canvas_activities_page.rb
+++ b/pages/canvas/canvas_activities_page.rb
@@ -173,7 +173,7 @@ module Page
       online_url_cbx_element.when_visible Utils.short_wait
     end
 
-    # Saves and publishes an assingment and returns its URL
+    # Saves and publishes an assignment and returns its URL
     # @param assignment [Assignment]
     # @return [String]
     def save_and_publish_assignment(assignment)

--- a/pages/page.rb
+++ b/pages/page.rb
@@ -175,7 +175,6 @@ module Page
   # are not scrolled into focus prior to an interaction.
   def scroll_to_bottom
     execute_script 'window.scrollTo(0, document.body.scrollHeight);'
-    sleep 1
   end
 
   # Uses JavaScript to scroll an element into view. If the attempt fails, it tries once more.

--- a/pages/suitec/impact_studio_page.rb
+++ b/pages/suitec/impact_studio_page.rb
@@ -488,7 +488,7 @@ module Page
         wait_for_update_and_click_js add_site_link_element
         switch_to_canvas_iframe driver
         enter_and_submit_url asset
-        asset.id = list_view_asset_ids.first
+        wait_for_asset_and_get_id asset
       end
 
       # Adds a file asset to the Asset Library via the Impact Studio
@@ -498,7 +498,7 @@ module Page
         wait_for_update_and_click_js upload_link_element
         switch_to_canvas_iframe driver
         enter_and_upload_file asset
-        asset.id = list_view_asset_ids.first
+        wait_for_asset_and_get_id asset
       end
 
       # Given a swim lane filter link element, clicks the element unless it is disabled

--- a/pages/suitec/suite_c_pages.rb
+++ b/pages/suitec/suite_c_pages.rb
@@ -69,6 +69,13 @@ module Page
       switch_to_canvas_iframe driver
     end
 
+    # Waits for asset list view to load when a new asset is created, then gets the asset's ID. Requires that the asset have a unique title.
+    # @param asset [Asset]
+    def wait_for_asset_and_get_id(asset)
+      wait_until { list_view_asset_link_elements.any? }
+      asset.id = DBUtils.get_asset_id_by_title asset
+    end
+
     # Given an array of assets, returns their IDs in descending order of creation
     # @param assets [Array<Asset>]
     # @return [Array<String>]
@@ -106,8 +113,7 @@ module Page
     def upload_file_to_library(asset, event = nil)
       click_upload_file_link
       enter_and_upload_file asset
-      wait_until { list_view_asset_link_elements.any? }
-      asset.id = DBUtils.get_asset_id_by_title(asset)
+      wait_for_asset_and_get_id asset
       add_event(event, EventType::CREATE, asset.id)
       add_event(event, EventType::VIEW)
     end
@@ -161,8 +167,7 @@ module Page
     def add_site(asset, event = nil)
       click_add_site_link
       enter_and_submit_url asset
-      wait_until { list_view_asset_link_elements.any? }
-      asset.id = DBUtils.get_asset_id_by_title(asset)
+      wait_for_asset_and_get_id asset
       add_event(event, EventType::CREATE, asset.id)
       add_event(event, EventType::VIEW)
     end

--- a/spec/suitec/asset_library_content_spec.rb
+++ b/spec/suitec/asset_library_content_spec.rb
@@ -7,6 +7,7 @@ describe 'New asset uploads', order: :defined do
   begin
 
     timeout = Utils.short_wait
+    test_id = Utils.get_test_id
 
     @course = Course.new({})
     @course.site_id = ENV['COURSE_ID']
@@ -33,7 +34,7 @@ describe 'New asset uploads', order: :defined do
 
           begin
             @asset = Asset.new asset
-            asset_title = @asset.title
+            asset_title = (@asset.title = "#{@asset.title} #{test_id}")
             asset_preview_type = @asset.preview
             @asset.description = nil
             @asset.category = nil

--- a/spec/suitec/asset_library_manage_assets_spec.rb
+++ b/spec/suitec/asset_library_manage_assets_spec.rb
@@ -338,7 +338,8 @@ describe 'Asset', order: :defined do
 
       # Teacher creates an asset of each type in origin course site plus one extra that is deleted
       @asset_library.load_page(@driver, @asset_library_url)
-      @non_migrated_delete = Asset.new({type: 'File', file_name: 'image-jpegSmall-1.jpg', title: "#{destination_test_id} - Deleted File"})
+      @non_migrated_delete = Asset.new(teacher.assets.find { |a| a['type'] == 'File' })
+      @non_migrated_delete.title = "#{destination_test_id} - Deleted File"
       @asset_library.upload_file_to_library @non_migrated_delete
       @asset_library.load_asset_detail(@driver, @asset_library_url, @non_migrated_delete)
       @asset_library.delete_asset asset
@@ -346,7 +347,9 @@ describe 'Asset', order: :defined do
       @migrated_link = Asset.new({type: 'Link', url: 'https://news.google.com', title: "#{destination_test_id} - Migrated Link", description: 'Migrated link description'})
       @asset_library.add_site @migrated_link
 
-      @migrated_file = Asset.new({type: 'File', file_name: 'image-jpegSmall-2.jpg', title: "#{destination_test_id} - Migrated File", category: @category_1})
+      @migrated_file = Asset.new(teacher.assets.find { |a| a['type'] == 'File' })
+      @migrated_file.title = "#{destination_test_id} - Migrated File"
+      @migrated_file.category = @category_1
       @asset_library.upload_file_to_library @migrated_file
 
       @non_migrated_whiteboard = Whiteboard.new({owner: teacher, title: "#{destination_test_id} - Migrated Whiteboard", collaborators: []})

--- a/spec/suitec/asset_library_pins_spec.rb
+++ b/spec/suitec/asset_library_pins_spec.rb
@@ -15,9 +15,7 @@ describe 'Asset pinning', order: :defined do
   user_2_asset = Asset.new(user_2.assets.find { |a| a['type'] == 'File' })
   user_3_asset = Asset.new(user_3.assets.find { |a| a['type'] == 'File' })
 
-  user_1_asset.title = "User 1 asset #{test_id}"
-  user_2_asset.title = "User 2 asset #{test_id}"
-  user_3_asset.title = "User 3 asset #{test_id}"
+  [user_1_asset, user_2_asset, user_3_asset].each { |a| a.title = "#{a.title} #{test_id}" }
 
   pin = Activity::PIN_ASSET
   get_pin = Activity::GET_PIN_ASSET

--- a/spec/suitec/engagement_index_spec.rb
+++ b/spec/suitec/engagement_index_spec.rb
@@ -16,6 +16,7 @@ describe 'The Engagement Index', order: :defined do
   student_3 = User.new student_data[2]
   student_4 = User.new student_data[3]
   asset = Asset.new(student_3.assets.find { |asset| asset['type'] == 'File' })
+  asset.title = "#{asset.title} #{test_id}"
 
   before(:all) do
     @course = Course.new({})
@@ -150,7 +151,7 @@ describe 'The Engagement Index', order: :defined do
   it 'allows teachers to share their scores with students' do
     @engagement_index.share_score event
     @engagement_index.wait_until(Utils.short_wait) { @engagement_index.sharing_preference(teacher) == 'Yes' }
-    @canvas.masquerade_as(@driver, (event.user = student_4), @course)
+    @canvas.masquerade_as(@driver, (event.actor = student_4), @course)
     @engagement_index.load_scores(@driver, @engagement_index_url, event)
     expect(@engagement_index.visible_names).to include(teacher.full_name)
   end
@@ -208,7 +209,7 @@ describe 'The Engagement Index', order: :defined do
   end
 
   it 'allows students to hide their scores from other students' do
-    @engagement_index.un_share_score(events_csv, student_1)
+    @engagement_index.un_share_score event
   end
 
   it 'shows students who have not shared their scores only their own scores' do

--- a/spec/suitec/impact_studio_assets_spec.rb
+++ b/spec/suitec/impact_studio_assets_spec.rb
@@ -14,15 +14,17 @@ describe 'The Impact Studio', order: :defined do
   student_2 = students[1]
 
   # Get test assets
+  whiteboard = Whiteboard.new({owner: student_1, title: "Whiteboard #{test_id}", collaborators: [student_2]})
   all_assets = []
   all_assets << (asset_1 = Asset.new(student_1.assets.find { |a| a['type'] == 'Link' }))
   all_assets << (asset_2 = Asset.new((student_1.assets.select { |a| a['type'] == 'File' })[0]))
   all_assets << (asset_3 = Asset.new((student_1.assets.select { |a| a['type'] == 'File' })[1]))
-  all_assets << (asset_4 = Asset.new({}))
+  all_assets << (asset_4 = Asset.new({title: whiteboard.title, type: 'Whiteboard'}))
   all_assets << (asset_5 = Asset.new(teacher.assets.find { |a| a['type'] == 'File' }))
   all_assets << (asset_6 = Asset.new(student_2.assets.find { |a| a['type'] == 'File' }))
   all_assets << (asset_7 = Asset.new(student_2.assets.find { |a| a['type'] == 'Link' }))
-  whiteboard = Whiteboard.new({owner: student_1, title: "Whiteboard #{test_id}", collaborators: [student_2]})
+  # Append test ID to all asset titles, except whiteboard asset which will inherit test ID from its whiteboard
+  [asset_1, asset_2, asset_3, asset_5, asset_6, asset_7].each { |a| a.title = "#{a.title} #{test_id}" }
 
   student_1_assets = [asset_4, asset_3, asset_2, asset_1]
   student_2_assets = [asset_7, asset_6, asset_4]
@@ -106,11 +108,9 @@ describe 'The Impact Studio', order: :defined do
         @canvas.masquerade_as(@driver, student_1, @course)
         @impact_studio.load_page(@driver, @impact_studio_url)
         @impact_studio.add_site(@driver, asset_1)
-        logger.debug "Asset 1 ID is #{asset_1.id}"
-        @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
-      after(:all) { logger.debug "Asset 1 impact score is actually #{asset_1.impact_score = asset_1_actual_score}" }
+      after(:all) { asset_1.impact_score = asset_1_actual_score }
 
       it('stores a zero impact score') { expect(asset_1_actual_score = DBUtils.get_asset_impact_score(asset_1)).to eql(asset_1.impact_score) }
     end
@@ -122,19 +122,15 @@ describe 'The Impact Studio', order: :defined do
         @whiteboards.load_page(@driver, @whiteboards_url)
         @whiteboards.create_and_open_whiteboard(@driver, whiteboard)
         @whiteboards.add_asset_exclude_from_library asset_2
-        @whiteboards.open_original_asset_link_element.when_visible Utils.long_wait
-        logger.debug "Asset 2 ID is #{asset_2.id = @whiteboards.added_asset_id}"
-        asset_2.visible = false
 
         # Pin the asset to verify that invisible assets are not returned in 'Pinned' search results
         @whiteboards.open_original_asset(@driver, @asset_library, asset_2)
         @asset_library.pin_detail_view_asset asset_2
         @whiteboards.close_original_asset @driver
         @whiteboards.close_whiteboard @driver
-        @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
-      after(:all) { logger.debug "Asset 2 impact score is actually #{asset_2.impact_score = asset_2_actual_score}" }
+      after(:all) { asset_2.impact_score = asset_2_actual_score }
 
       it('stores a zero impact score') { expect(asset_2_actual_score = DBUtils.get_asset_impact_score(asset_2)).to eql(asset_2.impact_score) }
     end
@@ -146,14 +142,10 @@ describe 'The Impact Studio', order: :defined do
         @whiteboards.load_page(@driver, @whiteboards_url)
         @whiteboards.open_whiteboard(@driver, whiteboard)
         @whiteboards.add_asset_include_in_library asset_3
-        @whiteboards.open_original_asset_link_element.when_visible Utils.long_wait
         @whiteboards.close_whiteboard @driver
-        @asset_library.load_page(@driver, @asset_library_url)
-        logger.debug "Asset 3 ID is #{asset_3.id = @asset_library.list_view_asset_ids.first}"
-        @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
-      after(:all) { logger.debug "Asset 3 impact score is actually #{asset_3.impact_score = asset_3_actual_score}" }
+      after(:all) { asset_3.impact_score = asset_3_actual_score }
 
       it('stores a zero impact score') { expect(asset_3_actual_score = DBUtils.get_asset_impact_score(asset_3)).to eql(asset_3.impact_score) }
     end
@@ -165,15 +157,11 @@ describe 'The Impact Studio', order: :defined do
         @whiteboards.load_page(@driver, @whiteboards_url)
         @whiteboards.open_whiteboard(@driver, whiteboard)
         @whiteboards.export_to_asset_library whiteboard
+        asset_4.id = DBUtils.get_asset_id_by_title asset_4
         @whiteboards.close_whiteboard @driver
-        @asset_library.load_page(@driver, @asset_library_url)
-        logger.debug "Asset 4 ID is #{asset_4.id = @asset_library.list_view_asset_ids.first}"
-        asset_4.type = 'Whiteboard'
-        asset_4.title = whiteboard.title
-        @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
-      after(:all) { logger.debug "Asset 4 impact score is actually #{asset_4.impact_score = asset_4_actual_score}" }
+      after(:all) { asset_4.impact_score = asset_4_actual_score }
 
       it('stores a zero impact score') { expect(asset_4_actual_score = DBUtils.get_asset_impact_score(asset_4)).to eql(asset_4.impact_score) }
     end
@@ -185,11 +173,9 @@ describe 'The Impact Studio', order: :defined do
         @canvas.masquerade_as(@driver, teacher, @course)
         @impact_studio.load_page(@driver, @impact_studio_url)
         @impact_studio.add_file(@driver, asset_5)
-        logger.debug "Asset 5 ID is #{asset_5.id = @asset_library.list_view_asset_ids.first}"
-        @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
-      after(:all) { logger.debug "Asset 5 impact score is actually #{asset_5.impact_score = asset_5_actual_score}" }
+      after(:all) { asset_5.impact_score = asset_5_actual_score }
 
       it('stores a zero impact score for an asset uploaded via the Impact Studio') { expect(asset_5_actual_score = DBUtils.get_asset_impact_score(asset_5)).to eql(asset_5.impact_score) }
     end
@@ -201,11 +187,9 @@ describe 'The Impact Studio', order: :defined do
         @canvas.masquerade_as(@driver, student_2, @course)
         @asset_library.load_page(@driver, @asset_library_url)
         @asset_library.upload_file_to_library asset_6
-        logger.debug "Asset 6 ID is #{asset_6.id}"
-        @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
-      after(:all) { logger.debug "Asset 6 impact score is actually #{asset_6.impact_score = asset_6_actual_score}" }
+      after(:all) { asset_6.impact_score = asset_6_actual_score }
 
       it('stores a zero impact score') { expect(asset_6_actual_score = DBUtils.get_asset_impact_score(asset_6)).to eql(asset_6.impact_score) }
     end
@@ -216,16 +200,14 @@ describe 'The Impact Studio', order: :defined do
         # Student 2 add asset 7 via asset library
         @asset_library.load_page(@driver, @asset_library_url)
         @asset_library.add_site asset_7
-        logger.debug "Asset 7 ID is #{asset_7.id}"
 
         # Pin the asset to verify that deleted assets are not returned in 'Pinned' search results and then delete it
         @asset_library.load_asset_detail(@driver, @asset_library_url, asset_7)
         @asset_library.pin_detail_view_asset asset_7
         @asset_library.delete_asset asset_7
-        @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
-      after(:all) { logger.debug "Asset 7 impact score is actually #{asset_7.impact_score = asset_7_actual_score}" }
+      after(:all) { asset_7.impact_score = asset_7_actual_score }
 
       it('stores a zero impact score') { expect(asset_7_actual_score = DBUtils.get_asset_impact_score(asset_7)).to eql(asset_7.impact_score) }
     end
@@ -283,10 +265,10 @@ describe 'The Impact Studio', order: :defined do
         @whiteboards.add_existing_assets [asset_1]
         @whiteboards.open_original_asset_link_element.when_visible Utils.medium_wait
         @whiteboards.close_whiteboard @driver
-        logger.debug "Asset 1 impact score should be #{asset_1.impact_score += Activity::ADD_ASSET_TO_WHITEBOARD.impact_points}"
+        asset_1.impact_score += Activity::ADD_ASSET_TO_WHITEBOARD.impact_points
       end
 
-      after(:all) { logger.debug "Asset 1 impact score is actually #{asset_1.impact_score = asset_1_actual_score}" }
+      after(:all) { asset_1.impact_score = asset_1_actual_score }
 
       it('stores the impact score for the asset added to a whiteboard') { expect(asset_1_actual_score = DBUtils.get_asset_impact_score(asset_1)).to eql(asset_1.impact_score) }
 
@@ -319,10 +301,10 @@ describe 'The Impact Studio', order: :defined do
         # Teacher views the student's asset
         @canvas.masquerade_as(@driver, teacher, @course)
         @asset_library.load_asset_detail(@driver, @asset_library_url, asset_3)
-        logger.debug "Asset 3 impact score should be #{asset_3.impact_score += Activity::VIEW_ASSET.impact_points}"
+        asset_3.impact_score += Activity::VIEW_ASSET.impact_points
       end
 
-      after(:all) { logger.debug "Asset 3 impact score is actually #{asset_3.impact_score = asset_3_actual_score}" }
+      after(:all) { asset_3.impact_score = asset_3_actual_score }
 
       it('stores the right impact score for the viewed asset') { expect(asset_3_actual_score = DBUtils.get_asset_impact_score(asset_3)).to eql(asset_3.impact_score) }
 
@@ -356,7 +338,7 @@ describe 'The Impact Studio', order: :defined do
         asset_6.impact_score += Activity::COMMENT.impact_points
       end
 
-      after(:all) { logger.debug "Asset 6 impact score is actually #{asset_6.impact_score = asset_6_actual_score}" }
+      after(:all) { asset_6.impact_score = asset_6_actual_score }
 
       it('stores the right impact score for the commented-on asset') { expect(asset_6_actual_score = DBUtils.get_asset_impact_score(asset_6)).to eql(asset_6.impact_score) }
 
@@ -387,10 +369,10 @@ describe 'The Impact Studio', order: :defined do
 
         @asset_library.reply_to_comment(asset_6, 0, 'This is another comment from Teacher to Student 2')
         @asset_library.wait_until(Utils.short_wait) { @asset_library.asset_detail_comment_count == '2' }
-        logger.debug "Asset 6 impact score should be #{asset_6.impact_score += Activity::COMMENT.impact_points}"
+        asset_6.impact_score += Activity::COMMENT.impact_points
       end
 
-      after(:all) { logger.debug "Asset 6 impact score is actually #{asset_6.impact_score = asset_6_actual_score}" }
+      after(:all) { asset_6.impact_score = asset_6_actual_score }
 
       it('stores the right impact score for the commented-on asset') { expect(asset_6_actual_score = DBUtils.get_asset_impact_score(asset_6)).to eql(asset_6.impact_score) }
 
@@ -421,10 +403,10 @@ describe 'The Impact Studio', order: :defined do
 
         @asset_library.toggle_detail_view_item_like asset_5
         @asset_library.wait_until { @asset_library.detail_view_asset_likes_count == '1' }
-        logger.debug "Asset 5 impact score should be #{asset_5.impact_score += Activity::LIKE.impact_points}"
+        asset_5.impact_score += Activity::LIKE.impact_points
       end
 
-      after(:all) { logger.debug "Asset 5 impact score is actually #{asset_5.impact_score = asset_5_actual_score}" }
+      after(:all) { asset_5.impact_score = asset_5_actual_score }
 
       it('stores the right impact score for the liked asset') { expect(asset_5_actual_score = DBUtils.get_asset_impact_score(asset_5)).to eql(asset_5.impact_score) }
 
@@ -454,10 +436,10 @@ describe 'The Impact Studio', order: :defined do
         asset_4.impact_score += Activity::VIEW_ASSET.impact_points
 
         @asset_library.click_remix
-        logger.debug "Asset 4 impact score should be #{asset_4.impact_score += Activity::REMIX_WHITEBOARD.impact_points}"
+        asset_4.impact_score += Activity::REMIX_WHITEBOARD.impact_points
       end
 
-      after(:all) { logger.debug "Asset 4 impact score is actually #{asset_4.impact_score = asset_4_actual_score}" }
+      after(:all) { asset_4.impact_score = asset_4_actual_score }
 
       it('stores the right impact score for the remixed whiteboard asset') { expect(asset_4_actual_score = DBUtils.get_asset_impact_score(asset_4)).to eql(asset_4.impact_score) }
 
@@ -502,10 +484,9 @@ describe 'The Impact Studio', order: :defined do
       before(:all) do
         @asset_library.load_asset_detail(@driver, @asset_library_url, asset_4)
         @impact_studio.load_page(@driver, @impact_studio_url)
-        logger.debug "Asset 4 impact score should be #{asset_4.impact_score}"
       end
 
-      after(:all) { logger.debug "Asset 4 impact score is actually #{asset_4.impact_score = asset_4_actual_score}" }
+      after(:all) { asset_4.impact_score = asset_4_actual_score }
 
       it('shows the right assets in My Assets > Most Impactful') { @impact_studio.verify_user_impactful_assets(@driver, student_1_assets, student_1) }
       it('shows the right assets in Community Assets > Most Impactful') { @impact_studio.verify_all_impactful_assets(@driver, all_assets) }
@@ -518,10 +499,9 @@ describe 'The Impact Studio', order: :defined do
         @asset_library.load_asset_detail(@driver, @asset_library_url, asset_4)
         @asset_library.add_comment(asset_4, 'Impact-free comment')
         @impact_studio.load_page(@driver, @impact_studio_url)
-        logger.debug "Asset 4 impact score should be #{asset_4.impact_score}"
       end
 
-      after(:all) { logger.debug "Asset 4 impact score is actually #{asset_4.impact_score = asset_4_actual_score}" }
+      after(:all) { asset_4.impact_score = asset_4_actual_score }
 
       it('shows the right assets in My Assets > Most Impactful') { @impact_studio.verify_user_impactful_assets(@driver, student_1_assets, student_1) }
       it('shows the right assets in Community Assets > Most Impactful') { @impact_studio.verify_all_impactful_assets(@driver, all_assets) }
@@ -534,10 +514,9 @@ describe 'The Impact Studio', order: :defined do
         @asset_library.load_asset_detail(@driver, @asset_library_url, asset_4)
         @asset_library.click_remix
         @impact_studio.load_page(@driver, @impact_studio_url)
-        logger.debug "Asset 4 impact score should be #{asset_4.impact_score}"
       end
 
-      after(:all) { logger.debug "Asset 4 impact score is actually #{asset_4.impact_score = asset_4_actual_score}" }
+      after(:all) { asset_4.impact_score = asset_4_actual_score }
 
       it('shows the right assets in My Assets > Most Impactful') { @impact_studio.verify_user_impactful_assets(@driver, student_1_assets, student_1) }
       it('shows the right assets in Community Assets > Most Impactful') { @impact_studio.verify_all_impactful_assets(@driver, all_assets) }
@@ -553,13 +532,13 @@ describe 'The Impact Studio', order: :defined do
         @canvas.masquerade_as(@driver, teacher, @course)
 
         @asset_library.load_asset_detail(@driver, @asset_library_url, asset_6)
-        logger.debug "Asset 6 impact score should be #{asset_6.impact_score += Activity::VIEW_ASSET.impact_points}"
+        asset_6.impact_score += Activity::VIEW_ASSET.impact_points
 
         @asset_library.delete_comment(asset_6, 1)
-        logger.debug "Asset 6 impact score should be #{asset_6.impact_score -= Activity::COMMENT.impact_points}"
+        asset_6.impact_score -= Activity::COMMENT.impact_points
       end
 
-      after(:all) { logger.debug "Asset 6 impact score is actually #{asset_6.impact_score = asset_6_actual_score}" }
+      after(:all) { asset_6.impact_score = asset_6_actual_score }
 
       it('removes "comment" impact') { expect(asset_6_actual_score = DBUtils.get_asset_impact_score(asset_6)).to eql(asset_6.impact_score) }
 
@@ -587,10 +566,10 @@ describe 'The Impact Studio', order: :defined do
         asset_5.impact_score += Activity::VIEW_ASSET.impact_points
 
         @asset_library.toggle_detail_view_item_like asset_5
-        logger.debug "Asset 5 impact score should be #{asset_5.impact_score -= Activity::LIKE.impact_points}"
+        asset_5.impact_score -= Activity::LIKE.impact_points
       end
 
-      after(:all) { logger.debug "Asset 5 impact score is actually #{asset_5.impact_score = asset_5_actual_score}" }
+      after(:all) { asset_5.impact_score = asset_5_actual_score }
 
       it('removes "like" impact') { expect(asset_5_actual_score = DBUtils.get_asset_impact_score(asset_5)).to eql(asset_5.impact_score) }
 

--- a/spec/suitec/impact_studio_visualizations_spec.rb
+++ b/spec/suitec/impact_studio_visualizations_spec.rb
@@ -16,14 +16,15 @@ describe 'The Impact Studio', order: :defined do
 
   # Get test assets
   whiteboard = Whiteboard.new({owner: student_1, title: "Whiteboard #{test_id}", collaborators: [student_2]})
-  all_assets = []
-  all_assets << (asset_1 = Asset.new(student_1.assets.find { |a| a['type'] == 'Link' }))
-  all_assets << (asset_2 = Asset.new((student_1.assets.select { |a| a['type'] == 'File' })[0]))
-  all_assets << (asset_3 = Asset.new((student_1.assets.select { |a| a['type'] == 'File' })[1]))
-  all_assets << (asset_4 = Asset.new({title: whiteboard.title, type: 'Whiteboard'}))
-  all_assets << (asset_5 = Asset.new(teacher.assets.find { |a| a['type'] == 'File' }))
-  all_assets << (asset_6 = Asset.new(student_2.assets.find { |a| a['type'] == 'File' }))
-  all_assets << (asset_7 = Asset.new(student_2.assets.find { |a| a['type'] == 'Link' }))
+  asset_1 = Asset.new(student_1.assets.find { |a| a['type'] == 'Link' })
+  asset_2 = Asset.new((student_1.assets.select { |a| a['type'] == 'File' })[0])
+  asset_3 = Asset.new((student_1.assets.select { |a| a['type'] == 'File' })[1])
+  asset_4 = Asset.new({title: whiteboard.title, type: 'Whiteboard'})
+  asset_5 = Asset.new(teacher.assets.find { |a| a['type'] == 'File' })
+  asset_6 = Asset.new(student_2.assets.find { |a| a['type'] == 'File' })
+  asset_7 = Asset.new(student_2.assets.find { |a| a['type'] == 'Link' })
+  # Append test ID to all asset titles, except whiteboard asset which will inherit test ID from its whiteboard
+  [asset_1, asset_2, asset_3, asset_5, asset_6, asset_7].each { |a| a.title = "#{a.title} #{test_id}" }
   asset_1_activities, asset_3_activities, asset_4_activities, asset_5_activities, asset_6_activities = nil
 
   before(:all) do
@@ -109,7 +110,6 @@ describe 'The Impact Studio', order: :defined do
         @impact_studio.load_page(@driver, @impact_studio_url)
         @impact_studio.add_site(@driver, asset_1)
         student_1_activities[:add_asset][:count] += 1
-        logger.debug "Asset 1 ID is #{asset_1.id}"
         @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
@@ -128,8 +128,6 @@ describe 'The Impact Studio', order: :defined do
         @whiteboards.load_page(@driver, @whiteboards_url)
         @whiteboards.create_and_open_whiteboard(@driver, whiteboard)
         @whiteboards.add_asset_exclude_from_library asset_2
-        @whiteboards.open_original_asset_link_element.when_visible Utils.long_wait
-        logger.debug "Asset 2 ID is #{asset_2.id = @whiteboards.added_asset_id}"
         @whiteboards.close_whiteboard @driver
         @impact_studio.load_page(@driver, @impact_studio_url)
       end
@@ -149,10 +147,7 @@ describe 'The Impact Studio', order: :defined do
         @whiteboards.open_whiteboard(@driver, whiteboard)
         @whiteboards.add_asset_include_in_library asset_3
         student_1_activities[:add_asset][:count] += 1
-        @whiteboards.open_original_asset_link_element.when_visible Utils.long_wait
         @whiteboards.close_whiteboard @driver
-        @asset_library.load_page(@driver, @asset_library_url)
-        logger.debug "Asset 3 ID is #{asset_3.id = @asset_library.list_view_asset_ids.first}"
         @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
@@ -171,11 +166,10 @@ describe 'The Impact Studio', order: :defined do
         @whiteboards.load_page(@driver, @whiteboards_url)
         @whiteboards.open_whiteboard(@driver, whiteboard)
         @whiteboards.export_to_asset_library whiteboard
+        asset_4.id = DBUtils.get_asset_id_by_title asset_4
         student_1_activities[:export_whiteboard][:count] += 1
         student_2_activities[:export_whiteboard][:count] += 1
         @whiteboards.close_whiteboard @driver
-        @asset_library.load_page(@driver, @asset_library_url)
-        logger.debug "Asset 4 ID is #{asset_4.id = @asset_library.list_view_asset_ids.first}"
         @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
@@ -195,7 +189,6 @@ describe 'The Impact Studio', order: :defined do
         @impact_studio.load_page(@driver, @impact_studio_url)
         @impact_studio.add_file(@driver, asset_5)
         teacher_activities[:add_asset][:count] += 1
-        logger.debug "Asset 5 ID is #{asset_5.id = @asset_library.list_view_asset_ids.first}"
         @impact_studio.load_page(@driver, @impact_studio_url)
       end
 
@@ -215,7 +208,6 @@ describe 'The Impact Studio', order: :defined do
         @asset_library.load_page(@driver, @asset_library_url)
         @asset_library.upload_file_to_library asset_6
         student_2_activities[:add_asset][:count] += 1
-        logger.debug "Asset 6 ID is #{asset_6.id}"
         @impact_studio.load_page(@driver, @impact_studio_url)
       end
 

--- a/spec/suitec/whiteboard_management_spec.rb
+++ b/spec/suitec/whiteboard_management_spec.rb
@@ -247,6 +247,7 @@ describe 'Whiteboard', order: :defined do
       @assets = []
       user_asset_data.each do |data|
         asset = Asset.new data
+        asset.title = "#{asset.title} #{test_id}"
         (data['type'] == 'File') ? @asset_library.upload_file_to_library(asset) : @asset_library.add_site(asset)
         @asset_library.verify_first_asset(@student_1, asset)
         @assets << asset
@@ -329,6 +330,7 @@ describe 'Whiteboard', order: :defined do
       asset_detail_test_id = "#{Time.now.to_i}"
       @canvas.masquerade_as(@driver, @teacher, @course)
       @asset = Asset.new(@teacher.assets.find { |asset| asset['type'] == 'File' })
+      @asset.title = "#{@asset.title} #{test_id}"
       @asset_library.load_page(@driver, @asset_library_url)
       @asset_library.upload_file_to_library @asset
 


### PR DESCRIPTION
- Make sure SuiteC test scripts give their assets unique titles so that the asset ID can always be obtained
- Add a test for assignments with non-sync-able submission types