### PR TITLE
Use custom browser profiles to avoid relentless 2-step auth

### DIFF
--- a/pages/cal_net_page.rb
+++ b/pages/cal_net_page.rb
@@ -37,6 +37,7 @@ module Page
         wait_for_element_and_type_js(username_element, username)
         password_element.send_keys password
         wait_for_update_and_click sign_in_button_element
+        wait_until(Utils.medium_wait) { !current_url.include? Utils.cal_net_url }
         add_event(event, EventType::LOGGED_IN)
       end
     end

--- a/settings.yml
+++ b/settings.yml
@@ -1,4 +1,6 @@
-webdriver: chrome
+webdriver:
+  browser: chrome
+  firefox_profile: profile
 
 window:
   height: 0

--- a/util/utils.rb
+++ b/util/utils.rb
@@ -21,11 +21,11 @@ class Utils
 
   # Instantiates the browser and alters default browser settings.
   def self.launch_browser
-    driver = @config['webdriver']
+    driver = @config['webdriver']['browser']
     logger.info "Launching #{driver.capitalize}"
     if %w(firefox chrome safari).include? driver
       if driver == 'firefox'
-        profile = Selenium::WebDriver::Firefox::Profile.new
+        profile = Selenium::WebDriver::Firefox::Profile.from_name @config['webdriver']['firefox_profile']
         profile['browser.download.folderList'] = 2
         profile['browser.download.manager.showWhenStarting'] = false
         profile['browser.download.dir'] = Utils.download_dir
@@ -34,6 +34,7 @@ class Utils
         driver = Selenium::WebDriver.for :firefox, options: options
       elsif driver == 'chrome'
         options = Selenium::WebDriver::Chrome::Options.new
+        options.add_argument("user-data-dir=#{File.join(ENV['HOME'], '.webdriver-config/chrome-profile')}")
         prefs = {
           :prompt_for_download => false,
           :default_directory => Utils.download_dir


### PR DESCRIPTION
Avoid having to do 2-step auth for every test by using custom Chrome and Firefox profiles where authenticated session is maintained.