### PR TITLE
Simple script to perform configurable collaboration activities

### DIFF
--- a/pages/canvas/canvas_activities_page.rb
+++ b/pages/canvas/canvas_activities_page.rb
@@ -65,6 +65,7 @@ module Page
     # DISCUSSIONS
 
     link(:new_discussion_link, id: 'new-discussion-btn')
+    link(:subscribed_link, class: 'topic-unsubscribe-button')
     text_area(:discussion_title, id: 'discussion-title')
     checkbox(:threaded_discussion_cbx, id: 'threaded')
     checkbox(:graded_discussion_cbx, id: 'use_for_grading')
@@ -114,9 +115,10 @@ module Page
       discussion_title_element.when_present Utils.short_wait
       discussion_title_element.send_keys discussion.title
       js_click threaded_discussion_cbx_element
-      click_save_and_publish
+      teacher_role = save_and_publish_button?
+      teacher_role ? click_save_and_publish : wait_for_update_and_click_js(save_announcement_button_element)
       add_event(event, EventType::CREATE, discussion.title)
-      published_button_element.when_visible Utils.medium_wait
+      teacher_role ? published_button_element.when_visible(Utils.medium_wait) : subscribed_link_element.when_visible(Utils.medium_wait)
       logger.info "Discussion URL is #{current_url}"
       discussion.url = current_url
     end

--- a/pages/suitec/asset_library_page.rb
+++ b/pages/suitec/asset_library_page.rb
@@ -509,15 +509,34 @@ module Page
         (list_view_asset_like_button_elements.map { |button| button if button.enabled? }).to_a
       end
 
-      # Toggles the 'like' button on an asset's detail view
+      # Toggles the 'like' button on an asset's detail view and returns the 'like' count prior to toggling
       # @param asset [Asset]
       # @param event [Event]
+      # @return [String]
       def toggle_detail_view_item_like(asset, event = nil)
         logger.info 'Clicking the like button'
         wait_for_element(detail_view_asset_like_button_element, Utils.short_wait)
         already_liked = detail_view_asset_like_button_element.attribute('class').include? 'active'
+        count = detail_view_asset_likes_count
         js_click detail_view_asset_like_button_element
         already_liked ? add_event(event, EventType::REMOVE, asset.id) : add_event(event, EventType::LIKE, asset.id)
+        count
+      end
+
+      # Likes an asset and waits for its 'like' count to increment
+      # @param asset [Asset]
+      # @param event [Event]
+      def like_asset(asset, event = nil)
+        count = toggle_detail_view_item_like(asset, event)
+        wait_until(Utils.short_wait) { detail_view_asset_likes_count == "#{count.to_i + 1}" }
+      end
+
+      # Unlikes an asset and waits for its 'like' count to decrement
+      # @param asset [Asset]
+      # @param event [Event]
+      def unlike_asset(asset, event = nil)
+        count = toggle_detail_view_item_like(asset, event)
+        wait_until(Utils.short_wait) { detail_view_asset_likes_count == "#{count.to_i - 1}" }
       end
 
       # PINS

--- a/scripts/suitec_activity_network_script.rb
+++ b/scripts/suitec_activity_network_script.rb
@@ -1,0 +1,177 @@
+require_relative '../util/spec_helper'
+
+begin
+
+  include Logging
+  test_id = Utils.get_test_id
+  course_title = "Activity Network #{test_id}"
+  test_data = SuiteCUtils.load_suitec_test_data
+
+  # Load the test script CSV
+  test_script = CSV.table File.join(ENV['HOME'], '.webdriver-config/test-steps-activity-network.csv')
+
+  uids = test_script[:uid].uniq
+  user_data = test_data.select { |d| uids.include? d['uid'] }
+  users = user_data.map { |d| User.new(d) }
+  @assets = []
+  @comments = []
+  @whiteboards = []
+  @discussions = []
+
+  def find_asset(step)
+    @assets.find { |a| a.title.include? step[:asset] }
+  end
+
+  def find_comment(step)
+    @comments.find { |c| c.body.include? step[:comment] }
+  end
+
+  def find_whiteboard(step)
+    @whiteboards.find { |w| w.title.include? step[:whiteboard] }
+  end
+
+  def find_discussion(step)
+    @discussions.find { |d| d.title.include? step[:discussion] }
+  end
+
+  @course = Course.new({:title => course_title, :code => course_title})
+  @course.site_id = ENV['COURSE']
+
+  @driver = Utils.launch_browser
+  @canvas = Page::CanvasActivitiesPage.new @driver
+  @cal_net = Page::CalNetPage.new @driver
+  @asset_library_page = Page::SuiteCPages::AssetLibraryPage.new @driver
+  @impact_studio_page = Page::SuiteCPages::ImpactStudioPage.new @driver
+  @whiteboards_page = Page::SuiteCPages::WhiteboardsPage.new @driver
+
+  # Create course site if necessary
+  @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
+  @canvas.create_generic_course_site(@driver, Utils.canvas_qa_sub_account, @course, users, test_id,
+                                     [LtiTools::ASSET_LIBRARY, LtiTools::IMPACT_STUDIO, LtiTools::WHITEBOARDS])
+  @asset_library_page_url = @canvas.click_tool_link(@driver, LtiTools::ASSET_LIBRARY)
+  @impact_studio_page_url = @canvas.click_tool_link(@driver, LtiTools::IMPACT_STUDIO)
+  @whiteboards_url = @canvas.click_tool_link(@driver, LtiTools::WHITEBOARDS)
+
+  test_script.each do |step|
+
+    step_number = test_script.find_index(step) + 1
+    logger.info "Executing step #{step_number}: #{step[:test_case]}"
+
+    begin
+
+      # Determine which user will take action
+      user = users.find { |u| u.uid == step[:uid] }
+      @canvas.masquerade_as(@driver, user, @course)
+
+      # Determine which action to take
+      case step[:action]
+
+        # ASSETS
+
+        when 'add_asset'
+          asset = Asset.new user.assets.first
+          asset.title = "#{step[:asset]} - #{test_id}"
+          @asset_library_page.load_page(@driver, @asset_library_page_url)
+          asset.type == 'File' ?
+              @asset_library_page.upload_file_to_library(asset) :
+              @asset_library_page.add_site(asset)
+          @assets << asset
+
+        when 'view_asset'
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, find_asset(step))
+
+        when 'like'
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, asset = find_asset(step))
+          @asset_library_page.like_asset asset
+
+        when 'unlike'
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, asset = find_asset(step))
+          @asset_library_page.unlike_asset asset
+
+        when 'comment'
+          asset = find_asset step
+          comment = Comment.new(user, "#{asset.title} - #{step[:comment]}")
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, asset)
+          @asset_library_page.add_comment(asset, comment)
+          @comments << comment
+
+        when 'comment_reply'
+          comment = find_comment(step)
+          reply = Comment.new(user, "#{comment.body} - #{step[:reply]}")
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, asset = find_asset(step))
+          @asset_library_page.reply_to_comment(asset, comment, reply)
+
+        when 'delete_comment'
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, asset = find_asset(step))
+          @asset_library_page.delete_comment(asset, find_comment(step))
+
+        when 'pin_asset'
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, asset = find_asset(step))
+          @asset_library_page.pin_detail_view_asset asset
+
+        when 'unpin_asset'
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, asset = find_asset(step))
+          @asset_library_page.unpin_detail_view_asset asset
+
+        when 'delete_asset'
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, asset = find_asset(step))
+          @asset_library_page.delete_asset asset
+
+        # WHITEBOARDS
+
+        when 'add_whiteboard'
+          collaborators = users.select { |u| step[:collaborators].include? "#{u.uid}" }
+          whiteboard = Whiteboard.new(:title => "#{step[:whiteboard]} - #{test_id}", :collaborators => collaborators)
+          @whiteboards_page.load_page(@driver, @whiteboards_url)
+          @whiteboards_page.create_whiteboard whiteboard
+          @whiteboards << whiteboard
+
+        when 'whiteboard_add_asset'
+          @whiteboards_page.load_page(@driver, @whiteboards_url)
+          @whiteboards_page.open_whiteboard(@driver, find_whiteboard(step))
+          @whiteboards_page.add_existing_assets [find_asset(step)]
+          @whiteboards_page.close_whiteboard @driver
+
+        when 'export_whiteboard'
+          @whiteboards_page.load_page(@driver, @whiteboards_url)
+          @whiteboards_page.open_whiteboard(@driver, whiteboard = find_whiteboard(step))
+          asset = @whiteboards_page.export_to_asset_library(whiteboard)
+          @assets << asset
+
+        when 'remix_whiteboard'
+          @asset_library_page.load_asset_detail(@driver, @asset_library_page_url, find_asset(step))
+          whiteboard = @asset_library_page.click_remix
+          @whiteboards << whiteboard
+
+        # DISCUSSIONS
+
+        when 'discussion_topic'
+          discussion = Discussion.new "#{step[:discussion]} - #{test_id}"
+          @canvas.create_course_discussion(@driver, @course, discussion)
+          @discussions << discussion
+
+        when 'discussion_entry'
+          @canvas.add_reply(find_discussion(step), nil, "#{step[:reply]} - #{test_id}")
+
+        when 'delete_discussion'
+          discussion = find_discussion step
+          @canvas.delete_activity(discussion.title, discussion.url)
+
+        else
+          logger.error "Step not supported: #{step}"
+
+      end
+
+      @impact_studio_page.load_page(@driver, @impact_studio_page_url)
+      sleep Utils.short_wait
+      Utils.save_screenshot(@driver, "#{test_id}-step#{step_number}-#{step[:uid]}-#{step[:action]}")
+
+    rescue => e
+      logger.error "Step failed: #{step}"
+      Utils.log_error e
+    end
+  end
+
+ensure
+  Utils.quit_browser @driver
+end

--- a/util/utils.rb
+++ b/util/utils.rb
@@ -276,6 +276,7 @@ class Utils
   def self.save_screenshot(driver, unique_id)
     output_dir = File.join(ENV['HOME'], '/webdriver-output/screenshots')
     FileUtils.mkdir_p(output_dir) unless File.exists?(output_dir)
+    logger.info "Saving screenshot named '#{unique_id}.png'"
     driver.save_screenshot File.join(output_dir, "#{unique_id}.png")
   end
 


### PR DESCRIPTION
Script loads a CSV and performs the actions indicated in each of the CSV rows. A sample CSV will be added separately. The script takes a screenshot of the Activity Network after each action.