### PR TITLE
Avoid total script failures caused by deploys

### DIFF
--- a/spec/boac/boac_dashboard_teams_spec.rb
+++ b/spec/boac/boac_dashboard_teams_spec.rb
@@ -36,7 +36,7 @@ describe 'BOAC' do
 
           expected_team_members = BOACUtils.get_team_members(team, athletes).sort_by! &:full_name
 
-          @boac_homepage.click_home
+          @boac_homepage.load_page
           @boac_homepage.click_team_link team
           team_url = @boac_cohort_page.current_url
 


### PR DESCRIPTION
A long-running script often hits interruptions caused by deploys, leaving it with an unfamiliar UI.  Instead of looking for the Home button for each user, just hit the homepage URL.