### PR TITLE
Handle secondary sections in BOAC tests

### DIFF
--- a/pages/boac/api_user_analytics_page.rb
+++ b/pages/boac/api_user_analytics_page.rb
@@ -23,8 +23,13 @@ class ApiUserAnalyticsPage
     @parsed['sisProfile']
   end
 
-  def plan
-    sis_profile['plan'] && sis_profile['plan']['description']
+  def majors
+    sis_profile['plans'] && sis_profile['plans'].map { |p| p['description'] }
+  end
+
+  def colleges
+    colleges = sis_profile['plans'] && sis_profile['plans'].map { |p| p['program'] }
+    colleges.compact if colleges
   end
 
   def level
@@ -86,26 +91,30 @@ class ApiUserAnalyticsPage
     term['enrollments']
   end
 
-  def course_site_name(course)
-    course['courseName']
+  def sections(course)
+    course['sections']
   end
 
-  def course_site_code(course)
-    course['courseCode']
+  def section_sis_data(section)
+    {
+      :ccn => section['ccn'],
+      :number => "#{section['sectionNumber']}",
+      :grading_basis => section['gradingBasis'],
+      :component => section['component'],
+      :units => section['units'].to_s,
+      :grade => section['grade'],
+      :status => section['enrollmentStatus']
+    }
   end
 
   def course_sis_data(course)
     {
       :code => course['displayName'],
-      :title => course['title'].gsub(/\s+/, ' '),
-      :status => course['enrollmentStatus'],
-      :number => course['sectionNumber'],
-      :units => course['units'].to_s,
-      :grading_basis => course['gradingBasis'],
-      :ccn => course['ccn'],
-      :grade => course['grade']
+      :title => course['title'].gsub(/\s+/, ' ')
     }
   end
+
+  # COURSE SITES
 
   def course_sites(course)
     course['canvasSites']

--- a/spec/boac/boac_team_member_data_spec.rb
+++ b/spec/boac/boac_team_member_data_spec.rb
@@ -10,13 +10,17 @@ describe 'BOAC' do
     teams_to_test = ENV['TEAMS']
 
     # Create file for test output
-    user_profile_data = File.join(Utils.initialize_test_output_dir, 'boac-profiles.csv')
-    user_profile_data_heading = %w(UID Sport Name Email Phone Units GPA Plan Level Writing History Institutions Cultures Language)
-    CSV.open(user_profile_data, 'wb') { |csv| csv << user_profile_data_heading }
+    user_profile_sis_data = File.join(Utils.initialize_test_output_dir, 'boac-sis-profiles.csv')
+    user_profile_data_heading = %w(UID Sport Name Email Phone Units GPA Colleges Majors Level Writing History Institutions Cultures Language)
+    CSV.open(user_profile_sis_data, 'wb') { |csv| csv << user_profile_data_heading }
 
-    user_course_data = File.join(Utils.initialize_test_output_dir, 'boac-courses.csv')
-    user_course_data_heading = %w(UID Sport CourseCode CourseName SectionCcn SectionNumber Grade GradingBasis Units EnrollmentStatus PageViews Assignments Participations)
-    CSV.open(user_course_data, 'wb') { |csv| csv << user_course_data_heading }
+    user_course_sis_data = File.join(Utils.initialize_test_output_dir, 'boac-sis-courses.csv')
+    user_course_data_heading = %w(UID Sport Term CourseCode CourseName SectionCcn SectionNumber Grade GradingBasis Units EnrollmentStatus)
+    CSV.open(user_course_sis_data, 'wb') { |csv| csv << user_course_data_heading }
+
+    user_course_canvas_data = File.join(Utils.initialize_test_output_dir, 'boac-canvas-courses.csv')
+    user_canvas_data_heading = %w(UID Sport Term CourseCode CourseName SiteTitle PageViews Assignments Participations)
+    CSV.open(user_course_canvas_data, 'wb') { |csv| csv << user_canvas_data_heading }
 
     # Get all teams and athletes
     athletes = BOACUtils.get_athletes
@@ -36,7 +40,7 @@ describe 'BOAC' do
     teams.select! { |t| teams_to_test.split(',').include? t.code } if teams_to_test
 
     teams.each do |team|
-      if visible_team_names.include?(team.name) && teams_to_test.include?(team.code)
+      if visible_team_names.include? team.name
         begin
 
           expected_team_members = BOACUtils.get_team_members(team, athletes).sort_by! &:full_name
@@ -74,7 +78,8 @@ describe 'BOAC' do
                 visible_phone = @boac_student_page.phone
                 visible_cumulative_units = @boac_student_page.cumulative_units
                 visible_cumulative_gpa = @boac_student_page.cumulative_gpa
-                visible_plan = @boac_student_page.plan
+                visible_majors = @boac_student_page.visible_majors
+                visible_colleges = @boac_student_page.visible_colleges
                 visible_level = @boac_student_page.level
                 visible_writing_reqt = @boac_student_page.writing_reqt.strip
                 visible_history_reqt = @boac_student_page.history_reqt.strip
@@ -103,16 +108,13 @@ describe 'BOAC' do
                   expect(visible_cumulative_gpa.empty?).to be false
                 end
 
-                # TODO - 'from' date
-                if user_analytics_data.plan
-                  it "shows the academic plan for UID #{team_member.uid}" do
-                    expect(visible_plan).to eql(user_analytics_data.plan)
-                  end
-                else
-                  it "shows no academic plan for UID #{team_member.uid}" do
-                    expect(visible_plan.empty?).to be true
-                  end
-                end
+                user_analytics_data.majors ?
+                    (it("shows the majors for UID #{team_member.uid}") { expect(visible_majors).to eql(user_analytics_data.majors) }) :
+                    (it("shows no majors for UID #{team_member.uid}") { expect(visible_majors).to be_empty })
+
+                user_analytics_data.colleges ?
+                    (it("shows the colleges for UID #{team_member.uid}") { expect(visible_colleges).to eql(user_analytics_data.colleges) }) :
+                    (it("shows no colleges for UID #{team_member.uid}") { expect(visible_colleges).to be_empty })
 
                 it "shows the academic level for UID #{team_member.uid}" do
                   expect(visible_level).to eql(user_analytics_data.level)
@@ -165,7 +167,7 @@ describe 'BOAC' do
 
                       if courses.any?
 
-                        term_course_ccns = []
+                        term_section_ccns = []
 
                         # COURSES
 
@@ -175,65 +177,105 @@ describe 'BOAC' do
                             site_page_view_analytics, site_assignment_analytics, site_participation_analytics = nil
 
                             course_sis_data = user_analytics_data.course_sis_data course
-                            term_course_ccns << course_sis_data[:ccn]
-
-                            logger.info "Checking course #{course_sis_data[:code]}"
-
                             course_code = course_sis_data[:code]
 
-                            visible_course_sis_data = @boac_student_page.visible_course_sis_data(term_name, course_code)
-                            visible_course_title = visible_course_sis_data[:title]
-                            visible_enrollment_status = visible_course_sis_data[:status]
-                            visible_section_number = visible_course_sis_data[:number]
-                            visible_section_units = visible_course_sis_data[:units]
-                            visible_section_grading_basis = visible_course_sis_data[:grading_basis]
-                            visible_grade = visible_course_sis_data[:grade]
+                            logger.info "Checking course #{course_code}"
+
+                            visible_course_title = @boac_student_page.course_title(term_name, course_code)
 
                             it "shows the course title for UID #{team_member.uid} term #{term_name} course #{course_code}" do
                               expect(visible_course_title).to eql(course_sis_data[:title])
                               expect(visible_course_title.empty?).to be false
                             end
 
-                            it "shows the course enrollment status for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_enrollment_status.empty?).to be false
-                              case (course_sis_data[:status])
-                                when 'E'
-                                  expect(visible_enrollment_status).to eql('Enrolled in')
-                                when 'W'
-                                  expect(visible_enrollment_status).to eql('Waitlisted in')
-                                when 'D'
-                                  expect(visible_enrollment_status).to eql('Dropped')
-                                else
-                                  logger.error "Invalid course status #{course_sis_data[:status]} for UID #{team_member.uid} term #{term_name} course #{course_code}"
-                                  fail
+                            sections = user_analytics_data.sections course
+                            if sections.any?
+
+                              # SECTIONS
+
+                              sections.each do |section|
+
+                                begin
+
+                                  section_sis_data = user_analytics_data.section_sis_data section
+                                  term_section_ccns << section_sis_data[:ccn]
+
+                                  component = section_sis_data[:component]
+
+                                  visible_section_sis_data = @boac_student_page.visible_section_sis_data(term_name, course_code, component)
+
+                                  visible_enrollment_status = visible_section_sis_data[:status]
+                                  visible_section_number = visible_section_sis_data[:number]
+                                  visible_section_units = visible_section_sis_data[:units]
+                                  visible_section_grading_basis = visible_section_sis_data[:grading_basis]
+                                  visible_grade = visible_section_sis_data[:grade]
+
+                                  it "shows the section enrollment status for UID #{team_member.uid} term #{term_name} course #{course_code}" do
+                                    case (section_sis_data[:status])
+                                      when 'E'
+                                        expect(visible_enrollment_status).to be_nil
+                                      when 'W'
+                                        expect(visible_enrollment_status).to eql('Waitlisted in')
+                                      when 'D'
+                                        expect(visible_enrollment_status).to eql('Dropped')
+                                      else
+                                        logger.error "Invalid course status #{section_sis_data[:status]} for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}"
+                                        fail
+                                    end
+                                  end
+
+                                  it "shows the section number for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}" do
+                                    expect(visible_section_number).to eql(section_sis_data[:number])
+                                    expect(visible_section_number.empty?).to be false
+                                  end
+
+                                  if section_sis_data[:units].to_i > 0
+                                    it "shows the section units for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}" do
+                                      expect(visible_section_units).to eql(section_sis_data[:units])
+                                      expect(visible_section_units.empty?).to be false
+                                    end
+                                  else
+                                    it "shows no section units for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}" do
+                                      expect(visible_section_units).to be_nil
+                                    end
+                                  end
+
+                                  if section_sis_data[:grading_basis] == 'NON'
+                                    it "shows not section grading basis for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}" do
+                                      expect(visible_section_grading_basis).to be_nil
+                                    end
+                                  else
+                                    it "shows the section grading basis for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}" do
+                                      expect(visible_section_grading_basis).to eql(section_sis_data[:grading_basis])
+                                      expect(visible_section_grading_basis.empty?).to be false
+                                    end
+                                  end
+
+                                  if section_sis_data[:grade]
+                                    it "shows the section grade data for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}" do
+                                      expect(visible_grade).to eql(section_sis_data[:grade])
+                                      expect(visible_grade.empty?).to be false
+                                    end
+                                  else
+                                    it "shows not section grade data for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}" do
+                                      expect(visible_grade).to be_nil
+                                    end
+                                  end
+
+                                rescue => e
+                                  Utils.log_error e
+                                  it("encountered an error for UID #{team_member.uid} term #{term_name} course #{course_code} section #{section_sis_data[:ccn]}") { fail }
+                                ensure
+                                  row = [team_member.uid, team.name, term_name, course_code, course_sis_data[:title], section_sis_data[:ccn], section_sis_data[:number],
+                                         section_sis_data[:grade], section_sis_data[:grading_basis], section_sis_data[:units], section_sis_data[:status]]
+                                  Utils.add_csv_row(user_course_sis_data, row)
+                                end
                               end
                             end
 
-                            it "shows the course number for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_section_number).to eql(course_sis_data[:number])
-                              expect(visible_section_number.empty?).to be false
-                            end
-
-                            it "shows the course units for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_section_units).to eql(course_sis_data[:units])
-                              expect(visible_section_units.empty?).to be false
-                            end
-
-                            it "shows the course grading basis for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_section_grading_basis).to eql(course_sis_data[:grading_basis])
-                              expect(visible_section_grading_basis.empty?).to be false
-                            end
-
-                            it("shows the course grade data for UID #{team_member.uid} term #{term_name} course #{course_code}") { expect(visible_grade).to eql(course_sis_data[:grade]) }
-
-                            course_sis_data[:grade] ?
-                                (it("shows a grade for UID #{team_member.uid} term #{term_name} course #{course_code}") { expect(visible_grade).not_to be_nil }) :
-                                (it("shows no grade for UID #{team_member.uid} term #{term_name} course #{course_code}") { expect(visible_grade).to be_nil })
-
-                            course_sites = user_analytics_data.course_sites course
-
                             # COURSE SITE ANALYTICS
 
+                            course_sites = user_analytics_data.course_sites course
                             if course_sites.any?
 
                               logger.warn "The number of sites attached to #{course_code} is #{course_sites.length}"
@@ -244,77 +286,75 @@ describe 'BOAC' do
                                   site_page_view_analytics, site_assignment_analytics, site_participation_analytics = nil
                                   site_title = user_analytics_data.site_metadata(site)[:title]
 
-                                  index = user_analytics_data.course_sites(course).index site
-                                  analytics_xpath = @boac_student_page.course_site_xpath(term_name, course_code, index)
-                                  logger.info "Checking course site #{site_title} at index #{index}"
+                                    index = user_analytics_data.course_sites(course).index site
+                                    analytics_xpath = @boac_student_page.course_site_xpath(term_name, course_code, index)
+                                    logger.info "Checking course site #{site_title} at index #{index}"
 
-                                  # Page views
+                                    # Page views
 
-                                  page_views_analytics = user_analytics_data.site_page_views site
-                                  site_page_view_analytics = user_analytics_data.site_statistics page_views_analytics
+                                    page_views_analytics = user_analytics_data.site_page_views site
+                                    site_page_view_analytics = user_analytics_data.site_statistics page_views_analytics
 
-                                  if user_analytics_data.student_percentile(page_views_analytics) && site_page_view_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
-                                    visible_page_view_analytics = @boac_student_page.visible_page_view_analytics(@driver, analytics_xpath)
-                                    it "shows the page view analytics for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
-                                      expect(visible_page_view_analytics).to eql(site_page_view_analytics)
+                                    if user_analytics_data.student_percentile(page_views_analytics) && site_page_view_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
+                                      visible_page_view_analytics = @boac_student_page.visible_page_view_analytics(@driver, analytics_xpath)
+                                      it "shows the page view analytics for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
+                                        expect(visible_page_view_analytics).to eql(site_page_view_analytics)
+                                      end
+                                    else
+                                      no_data = @boac_student_page.no_page_view_data? analytics_xpath
+                                      it "shows no page view data for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
+                                        expect(no_data).to be true
+                                      end
                                     end
-                                  else
-                                    no_data = @boac_student_page.no_page_view_data? analytics_xpath
-                                    it "shows no page view data for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
-                                      expect(no_data).to be true
+
+                                    # Assignments on time
+
+                                    assignments_on_time_analytics = user_analytics_data.site_assignments_on_time site
+                                    site_assignment_analytics = user_analytics_data.site_statistics assignments_on_time_analytics
+
+                                    if user_analytics_data.student_percentile(assignments_on_time_analytics) && site_assignment_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
+                                      visible_assignment_analytics = @boac_student_page.visible_assignment_analytics(@driver, analytics_xpath)
+                                      it "shows the assignments on time analytics for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
+                                        expect(visible_assignment_analytics).to eql(site_assignment_analytics)
+                                      end
+                                    else
+                                      no_data = @boac_student_page.no_assignment_data? analytics_xpath
+                                      it "shows no assignments on time data for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
+                                        expect(no_data).to be true
+                                      end
                                     end
-                                  end
 
-                                  # Assignments on time
+                                    # Participations
 
-                                  assignments_on_time_analytics = user_analytics_data.site_assignments_on_time site
-                                  site_assignment_analytics = user_analytics_data.site_statistics assignments_on_time_analytics
+                                    participation_analytics = user_analytics_data.site_participations site
+                                    site_participation_analytics = user_analytics_data.site_statistics participation_analytics
 
-                                  if user_analytics_data.student_percentile(assignments_on_time_analytics) && site_assignment_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
-                                    visible_assignment_analytics = @boac_student_page.visible_assignment_analytics(@driver, analytics_xpath)
-                                    it "shows the assignments on time analytics for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
-                                      expect(visible_assignment_analytics).to eql(site_assignment_analytics)
+                                    if user_analytics_data.student_percentile(participation_analytics) && site_participation_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
+                                      visible_participation_analytics = @boac_student_page.visible_participation_analytics(@driver, analytics_xpath)
+                                      it "shows the participations analytics for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
+                                        expect(visible_participation_analytics).to eql(site_participation_analytics)
+                                      end
+                                    else
+                                      no_data = @boac_student_page.no_participations_data? analytics_xpath
+                                      it "shows no participations data for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
+                                        expect(no_data).to be true
+                                      end
                                     end
-                                  else
-                                    no_data = @boac_student_page.no_assignment_data? analytics_xpath
-                                    it "shows no assignments on time data for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
-                                      expect(no_data).to be true
-                                    end
-                                  end
-
-                                  # Participations
-
-                                  participation_analytics = user_analytics_data.site_participations site
-                                  site_participation_analytics = user_analytics_data.site_statistics participation_analytics
-
-                                  if user_analytics_data.student_percentile(participation_analytics) && site_participation_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
-                                    visible_participation_analytics = @boac_student_page.visible_participation_analytics(@driver, analytics_xpath)
-                                    it "shows the participations analytics for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
-                                      expect(visible_participation_analytics).to eql(site_participation_analytics)
-                                    end
-                                  else
-                                    no_data = @boac_student_page.no_participations_data? analytics_xpath
-                                    it "shows no participations data for UID #{team_member.uid} term #{term_name} course site #{site_title}" do
-                                      expect(no_data).to be true
-                                    end
-                                  end
 
                                 rescue => e
                                   Utils.log_error e
                                   it("encountered an error for UID #{team_member.uid} term #{term_name} course #{course_code} site #{site_title}") { fail }
                                 ensure
-                                  row = [team_member.uid, team.name, course_code, course_sis_data[:title], course_sis_data[:ccn], course_sis_data[:number],
-                                         course_sis_data[:grade], course_sis_data[:grading_basis], course_sis_data[:units], course_sis_data[:status],
+                                  row = [team_member.uid, team.name, term_name, course_code, course_sis_data[:title], site_title,
                                          site_page_view_analytics, site_assignment_analytics, site_participation_analytics]
-                                  Utils.add_csv_row(user_course_data, row)
+                                  Utils.add_csv_row(user_course_canvas_data, row)
                                 end
                               end
 
                             else
                               logger.warn "#{course_code} has no sites"
-                              row = [team_member.uid, team.name, course_code, course_sis_data[:title], course_sis_data[:ccn], course_sis_data[:number],
-                                     course_sis_data[:grade], course_sis_data[:grading_basis], course_sis_data[:units], course_sis_data[:status]]
-                              Utils.add_csv_row(user_course_data, row)
+                              row = [team_member.uid, team.name, term_name, course_code, course_sis_data[:title]]
+                              Utils.add_csv_row(user_course_canvas_data, row)
                             end
 
                           rescue => e
@@ -323,7 +363,7 @@ describe 'BOAC' do
                           end
                         end
 
-                        it("shows no dupe courses for UID #{team_member.uid} in term #{term_name}") { expect(term_course_ccns).to eql(term_course_ccns.uniq) }
+                        it("shows no dupe courses for UID #{team_member.uid} in term #{term_name}") { expect(term_section_ccns).to eql(term_section_ccns.uniq) }
 
                       else
                         logger.warn "No course data in #{term_name}"
@@ -340,73 +380,71 @@ describe 'BOAC' do
                           begin
 
                             # Initialize SIS and analytics variables
-                            course_title, ccn, number, grade, grading_basis, units, status = nil
                             site_page_view_analytics, site_assignment_analytics, site_participation_analytics = nil
 
                             index = user_analytics_data.unmatched_sites(term).index site
                             site_title = user_analytics_data.site_metadata(site)[:title]
-                            analytics_xpath = @boac_student_page.unmatched_site_xpath(term_name, site_title, index)
+                              analytics_xpath = @boac_student_page.unmatched_site_xpath(term_name, site_title, index)
 
-                            logger.info "Checking unmatched site #{site_title} at index #{index}"
+                              logger.info "Checking unmatched site #{site_title} at index #{index}"
 
-                            # Page views
+                              # Page views
 
-                            page_views_analytics = user_analytics_data.site_page_views site
-                            site_page_view_analytics = user_analytics_data.site_statistics page_views_analytics
+                              page_views_analytics = user_analytics_data.site_page_views site
+                              site_page_view_analytics = user_analytics_data.site_statistics page_views_analytics
 
-                            if user_analytics_data.student_percentile(page_views_analytics) && site_page_view_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
-                              visible_page_view_analytics = @boac_student_page.visible_page_view_analytics(@driver, analytics_xpath)
-                              it "shows the page view analytics for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
-                                expect(visible_page_view_analytics).to eql(site_page_view_analytics)
+                              if user_analytics_data.student_percentile(page_views_analytics) && site_page_view_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
+                                visible_page_view_analytics = @boac_student_page.visible_page_view_analytics(@driver, analytics_xpath)
+                                it "shows the page view analytics for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
+                                  expect(visible_page_view_analytics).to eql(site_page_view_analytics)
+                                end
+                              else
+                                no_data = @boac_student_page.no_page_view_data? analytics_xpath
+                                it "shows no page view data for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
+                                  expect(no_data).to be true
+                                end
                               end
-                            else
-                              no_data = @boac_student_page.no_page_view_data? analytics_xpath
-                              it "shows no page view data for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
-                                expect(no_data).to be true
+
+                              # Assignments on time
+
+                              assignments_on_time_analytics = user_analytics_data.site_assignments_on_time site
+                              site_assignment_analytics = user_analytics_data.site_statistics assignments_on_time_analytics
+
+                              if user_analytics_data.student_percentile(assignments_on_time_analytics) && site_assignment_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
+                                visible_assignment_analytics = @boac_student_page.visible_assignment_analytics(@driver, analytics_xpath)
+                                it "shows the assignments on time analytics for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
+                                  expect(visible_assignment_analytics).to eql(site_assignment_analytics)
+                                end
+                              else
+                                no_data = @boac_student_page.no_assignment_data? analytics_xpath
+                                it "shows no assignments on time data for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
+                                  expect(no_data).to be true
+                                end
                               end
-                            end
 
-                            # Assignments on time
+                              # Participations
 
-                            assignments_on_time_analytics = user_analytics_data.site_assignments_on_time site
-                            site_assignment_analytics = user_analytics_data.site_statistics assignments_on_time_analytics
+                              participation_analytics = user_analytics_data.site_participations site
+                              site_participation_analytics = user_analytics_data.site_statistics participation_analytics
 
-                            if user_analytics_data.student_percentile(assignments_on_time_analytics) && site_assignment_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
-                              visible_assignment_analytics = @boac_student_page.visible_assignment_analytics(@driver, analytics_xpath)
-                              it "shows the assignments on time analytics for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
-                                expect(visible_assignment_analytics).to eql(site_assignment_analytics)
+                              if user_analytics_data.student_percentile(participation_analytics) && site_participation_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
+                                visible_participation_analytics = @boac_student_page.visible_participation_analytics(@driver, analytics_xpath)
+                                it "shows the participations analytics for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
+                                  expect(visible_participation_analytics).to eql(site_participation_analytics)
+                                end
+                              else
+                                no_data = @boac_student_page.no_participations_data? analytics_xpath
+                                it "shows no participations data for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
+                                  expect(no_data).to be true
+                                end
                               end
-                            else
-                              no_data = @boac_student_page.no_assignment_data? analytics_xpath
-                              it "shows no assignments on time data for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
-                                expect(no_data).to be true
-                              end
-                            end
-
-                            # Participations
-
-                            participation_analytics = user_analytics_data.site_participations site
-                            site_participation_analytics = user_analytics_data.site_statistics participation_analytics
-
-                            if user_analytics_data.student_percentile(participation_analytics) && site_participation_analytics[:maximum].to_i >= BOACUtils.meaningful_minimum
-                              visible_participation_analytics = @boac_student_page.visible_participation_analytics(@driver, analytics_xpath)
-                              it "shows the participations analytics for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
-                                expect(visible_participation_analytics).to eql(site_participation_analytics)
-                              end
-                            else
-                              no_data = @boac_student_page.no_participations_data? analytics_xpath
-                              it "shows no participations data for #{team.name} UID #{team_member.uid} unmatched site #{site_title}" do
-                                expect(no_data).to be true
-                              end
-                            end
 
                           rescue => e
                             Utils.log_error e
                             it("encountered an error for #{team.name} UID #{team_member.uid} unmatched site #{site_title}") { fail }
                           ensure
-                            row = [team_member.uid, team.name, site_title, course_title, ccn, number, grade, grading_basis, units, status,
-                                   site_page_view_analytics, site_assignment_analytics, site_participation_analytics]
-                            Utils.add_csv_row(user_course_data, row)
+                            row = [team_member.uid, team.name, term_name, nil, nil, site_title, site_page_view_analytics, site_assignment_analytics, site_participation_analytics]
+                            Utils.add_csv_row(user_course_canvas_data, row)
                           end
                         end
 
@@ -429,9 +467,9 @@ describe 'BOAC' do
                 it("encountered an error for UID #{team_member.uid}") { fail }
               ensure
                 row = [team_member.uid, team.name, visible_name, visible_email, visible_phone, visible_cumulative_units, visible_cumulative_gpa,
-                       visible_plan, visible_level, visible_writing_reqt, visible_history_reqt, visible_institutions_reqt, visible_cultures_reqt,
-                       visible_language_reqt]
-                Utils.add_csv_row(user_profile_data, row)
+                       visible_colleges && visible_colleges * '; ', visible_majors && visible_majors * '; ', visible_level, visible_writing_reqt,
+                       visible_history_reqt, visible_institutions_reqt, visible_cultures_reqt, visible_language_reqt]
+                Utils.add_csv_row(user_profile_sis_data, row)
               end
 
             else


### PR DESCRIPTION
Script now follows three tracks per user, inspecting and exporting:
- SIS profile data
- SIS course section data
- Canvas course site data, matched and unmatched

A lot of indentation changes.