### PR TITLE
Verify SuiteC events

### DIFF
--- a/pages/canvas/canvas_page.rb
+++ b/pages/canvas/canvas_page.rb
@@ -672,17 +672,17 @@ module Page
       logger.info "#{tool.name} URL is #{url = current_url}"
       add_event(event, EventType::NAVIGATE)
       add_event(event, EventType::VIEW)
-      case tool.name
-        when LtiTools::ASSET_LIBRARY.name
+      case tool
+        when LtiTools::ASSET_LIBRARY
           add_event(event, EventType::LAUNCH_ASSET_LIBRARY)
           add_event(event, EventType::LIST_ASSETS)
-        when LtiTools::ENGAGEMENT_INDEX.name
+        when LtiTools::ENGAGEMENT_INDEX
           add_event(event, EventType::LAUNCH_ENGAGEMENT_INDEX)
           add_event(event, EventType::GET_ENGAGEMENT_INDEX)
-        when LtiTools::WHITEBOARDS.name
+        when LtiTools::WHITEBOARDS
           add_event(event, EventType::LAUNCH_WHITEBOARDS)
           add_event(event, EventType::LIST_WHITEBOARDS)
-        when LtiTools::IMPACT_STUDIO.name
+        when LtiTools::IMPACT_STUDIO
           add_event(event, EventType::LAUNCH_IMPACT_STUDIO)
         else
           logger.warn "Cannot add an event for '#{tool.name}'"

--- a/pages/page.rb
+++ b/pages/page.rb
@@ -221,10 +221,10 @@ module Page
       event.object = event_object
       values = [(event.time_str = Time.now.strftime('%Y-%m-%d %H:%M:%S')), event.actor.uid, (event.action = event_type).desc, event.object]
       csv = if EventType::CALIPER_EVENT_TYPES.include?(event_type)
-              LRSUtils.events_csv event
+              event.csv = LRSUtils.events_csv event
             elsif EventType::SUITEC_EVENT_TYPES.include?(event_type)
               logger.debug "Adding SuiteC event '#{event_type.desc}'"
-              SuiteCUtils.events_csv event
+              event.csv = SuiteCUtils.script_events_csv event
             else
               logger.error 'Event type not recognized'
             end

--- a/pages/suitec/whiteboards_page.rb
+++ b/pages/suitec/whiteboards_page.rb
@@ -243,6 +243,7 @@ module Page
         driver.switch_to.alert.accept rescue Selenium::WebDriver::Error::StaleElementReferenceError
         add_event(event, EventType::MODIFY, board)
         add_event(event, EventType::WHITEBOARD_SETTINGS, board)
+        add_event(event, EventType::LIST_WHITEBOARDS)
         driver.switch_to.window driver.window_handles.first
         switch_to_canvas_iframe driver
         add_event(event, EventType::VIEW)
@@ -439,7 +440,7 @@ module Page
       # @param event [Event]
       def add_existing_assets(assets, event = nil)
         click_add_existing_asset event
-        assets.each { |asset| wait_for_update_and_click text_area_element(xpath : "//input[@value = '#{asset.id}']") }
+        assets.each { |asset| wait_for_update_and_click text_area_element(xpath: "//input[@value = '#{asset.id}']") }
         wait_for_update_and_click_js add_selected_button_element
         add_selected_button_element.when_not_visible Utils.short_wait
         assets.each do |asset|

--- a/settings.yml
+++ b/settings.yml
@@ -28,6 +28,7 @@ suite_c:
   db_user: secret
   db_password: secret
   poller_retries: 20
+  acceptable_events_diff: 0.03
 
 canvas:
   base_url: https://ucberkeley.test.instructure.com

--- a/spec/suitec/asset_library_comments_spec.rb
+++ b/spec/suitec/asset_library_comments_spec.rb
@@ -233,4 +233,10 @@ describe 'An asset comment', order: :defined do
       expect(@engagement_index.user_score(@driver, @engagement_index_url, @asset_admirer, event)).to eql((@admirer_score.to_i + (Activity::COMMENT.points * 3)).to_s)
     end
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end

--- a/spec/suitec/asset_library_likes_spec.rb
+++ b/spec/suitec/asset_library_likes_spec.rb
@@ -153,4 +153,10 @@ describe 'Asset', order: :defined do
       @asset_library.wait_until(Utils.short_wait) { @asset_library.list_view_asset_view_count(0) == '2' }
     end
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end

--- a/spec/suitec/asset_library_pins_spec.rb
+++ b/spec/suitec/asset_library_pins_spec.rb
@@ -330,4 +330,10 @@ describe 'Asset pinning', order: :defined do
       end
     end
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end

--- a/spec/suitec/engagement_index_spec.rb
+++ b/spec/suitec/engagement_index_spec.rb
@@ -343,4 +343,10 @@ describe 'The Engagement Index', order: :defined do
 
     end
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end

--- a/spec/suitec/impact_studio_assets_spec.rb
+++ b/spec/suitec/impact_studio_assets_spec.rb
@@ -628,4 +628,10 @@ describe 'The Impact Studio', order: :defined do
       it('shows the other user\'s pinned assets under Assets > Pinned') { @impact_studio.verify_user_pinned_assets(@driver, student_2_pins, student_2, event) }
     end
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end

--- a/spec/suitec/impact_studio_search_spec.rb
+++ b/spec/suitec/impact_studio_search_spec.rb
@@ -155,4 +155,10 @@ describe 'Impact Studio', order: :defined do
       users.each { |user| @impact_studio.browse_previous_user(student_1, user, event) }
     end
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end

--- a/spec/suitec/whiteboard_assets_spec.rb
+++ b/spec/suitec/whiteboard_assets_spec.rb
@@ -360,4 +360,10 @@ describe 'Whiteboard Add Asset', order: :defined do
     it('does not allow a student user to delete it via the whiteboard') { expect(@asset_library.delete_asset_button?).to be false }
 
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end

--- a/spec/suitec/whiteboard_collaboration_spec.rb
+++ b/spec/suitec/whiteboard_collaboration_spec.rb
@@ -355,6 +355,8 @@ describe 'Whiteboard', order: :defined do
         [@whiteboard_1, @whiteboard_2, @whiteboard_3].each do |whiteboard|
           @whiteboards_driver_1.wait_until(Utils.long_wait) do
             @whiteboards_driver_1.hit_whiteboard_url(course, @whiteboards_url, whiteboard, event_driver_1)
+            @whiteboards_driver_1.add_event(event_driver_1, EventType::OPEN_WHITEBOARD)
+            @whiteboards_driver_1.add_event(event_driver_1, EventType::GET_CHAT_MSG)
             @whiteboards_driver_1.click_settings_button
             !@whiteboards_driver_1.collaborator_name(user).exists?
           end
@@ -371,4 +373,10 @@ describe 'Whiteboard', order: :defined do
       end
     end
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end

--- a/spec/suitec/whiteboard_management_spec.rb
+++ b/spec/suitec/whiteboard_management_spec.rb
@@ -355,6 +355,7 @@ describe 'Whiteboard', order: :defined do
       @asset_library.load_page(@driver, @asset_library_url, event)
       @asset_library.wait_until(Utils.medium_wait) { @asset_library.list_view_asset_link_elements.any? }
       @asset_library.wait_for_load_and_click_js @asset_library.list_view_asset_link_elements.first
+      @asset_library.add_event(event, EventType::VIEW_ASSET)
       @asset_library.delete_asset(nil, event)
 
       # Load the asset's detail
@@ -369,4 +370,10 @@ describe 'Whiteboard', order: :defined do
 
     it('links to the whiteboard asset detail') { @asset_library.click_whiteboard_usage_link(@whiteboard_exported, event) }
   end
+
+  describe 'events' do
+
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+  end
+
 end


### PR DESCRIPTION
Test scripts now compare the events tracked to the events written to the events table.  Since minor diffs seem to be unavoidable, the scripts do not expect exact matches.  Instead, they check whether the numbers are within a configurable range of one another.  They also create a CSV of events tracked and a CSV of events in the table for manual debugging.