### PR TITLE
Fixes for assignment submission tests

### DIFF
--- a/pages/boac/api_user_analytics_page.rb
+++ b/pages/boac/api_user_analytics_page.rb
@@ -199,13 +199,6 @@ class ApiUserAnalyticsPage
     site_statistics(analytics(site)['assignmentsOnTime']).merge!({:type => 'Assignments on Time'})
   end
 
-  # Returns a user's Canvas API Assignment Grades analytics on a course site
-  # @param site [Hash]
-  # @return [Hash]
-  def canvas_api_grades(site)
-    site_statistics(analytics(site)['courseCurrentScore']).merge!({:type => 'Assignment Grades'})
-  end
-
   # Returns a user's Canvas API Page Views analytics on a course site
   # @param site [Hash]
   # @return [Hash]
@@ -220,11 +213,18 @@ class ApiUserAnalyticsPage
     site_statistics(loch_analytics(site)['assignmentsOnTime'])
   end
 
+  # Returns a user's Data Loch Assignments Submitted on Time analytics on a course site
+  # @param site [Hash]
+  # @return [Hash]
+  def loch_assigns_submitted(site)
+    site_statistics(loch_analytics(site)['assignmentsSubmitted'])
+  end
+
   # Returns a user's Data Loch Current Scores analytics on a course site
   # @param site [Hash]
   # @return [Hash]
   def loch_grades(site)
-    site_statistics(loch_analytics(site)['currentScores'])
+    site_statistics(analytics(site)['courseCurrentScore']).merge!({:type => 'Assignment Grades'})
   end
 
   # Returns a user's Data Loch Page Views analytics on a course site

--- a/pages/canvas/canvas_announce_discuss_page.rb
+++ b/pages/canvas/canvas_announce_discuss_page.rb
@@ -82,12 +82,6 @@ module Page
     elements(:secondary_reply_input, :text_area, xpath: '//li[contains(@class,"entry")]//textarea[@class="reply-textarea"]')
     elements(:secondary_post_reply_button, :button, xpath: '//li[contains(@class,"entry")]//button[contains(.,"Post Reply")]')
 
-    # Clicks the 'save and publish' button using JavaScript rather than WebDriver
-    def click_save_and_publish
-      scroll_to_bottom
-      wait_for_update_and_click_js save_and_publish_button_element
-    end
-
     # Creates a discussion on a course site
     # @param driver [Selenium::WebDriver]
     # @param course [Course]

--- a/pages/canvas/canvas_page.rb
+++ b/pages/canvas/canvas_page.rb
@@ -84,6 +84,12 @@ module Page
       navigate_to "#{Utils.canvas_base_url}/accounts/#{sub_account}"
     end
 
+    # Clicks the 'save and publish' button using JavaScript rather than WebDriver
+    def click_save_and_publish
+      scroll_to_bottom
+      wait_for_update_and_click_js save_and_publish_button_element
+    end
+
     # COURSE SITE SETUP
 
     link(:create_site_link, xpath: '//a[contains(text(),"Create a Site")]')
@@ -410,7 +416,7 @@ module Page
       users.each do |user|
         logger.info "Removing #{user.role} UID #{user.uid} from course site ID #{course.site_id}"
         wait_for_update_and_click link_element(xpath: "//tr[@id='user_#{user.canvas_id}']//a[contains(@class,'al-trigger')]")
-        confirm(true) { wait_for_update_and_click link_element(xpath: "//tr[@id='user_#{user.canvas_id}']//a[@data-event='removeFromCourse']") }
+        confirm(true) { wait_for_update_and_click_js link_element(xpath: "//tr[@id='user_#{user.canvas_id}']//a[@data-event='removeFromCourse']") }
         remove_user_success_element.when_visible Utils.short_wait
         add_event(event, EventType::MODIFY, '"state": "deleted"')
         add_event(event, EventType::MODIFY, user.full_name)


### PR DESCRIPTION
Tests now compare counts of both assignments submitted and those submitted on-time.  Comparison is the student view of the assignment UI in Canvas versus the BOAC data derived from the Loch.