### PR TITLE
Simple alerts test

### DIFF
--- a/pages/boac/home_page.rb
+++ b/pages/boac/home_page.rb
@@ -37,13 +37,15 @@ module Page
       end
 
       # Authenticates using dev auth
-      def dev_auth
+      # @param user [User]
+      def dev_auth(user = nil)
         logger.info 'Logging in using developer auth'
         load_page
         scroll_to_bottom
-        wait_for_element_and_type(dev_auth_uid_input_element, Utils.super_admin_uid)
+        wait_for_element_and_type(dev_auth_uid_input_element, (user ? user.uid : Utils.super_admin_uid))
         wait_for_element_and_type(dev_auth_password_input_element, BOACUtils.password)
         wait_for_update_and_click dev_auth_log_in_button_element
+        wait_for_title 'Home'
       end
 
       # MY LIST

--- a/pages/boac/student_page.rb
+++ b/pages/boac/student_page.rb
@@ -55,7 +55,9 @@ module Page
       # @return [Array<String>]
       def dismissed_alert_msgs
         click_view_dismissed_alerts if view_dismissed_button_element.visible?
-        dismissed_alert_msg_elements.map &:text
+        msgs = dismissed_alert_msg_elements.map &:text
+        click_hide_dismissed_alerts
+        msgs
       end
 
       # Clicks the button to reveal dismissed alerts
@@ -68,6 +70,13 @@ module Page
       def click_hide_dismissed_alerts
         logger.info "Clicking hide dismissed alerts button"
         wait_for_load_and_click hide_dismissed_button_element
+      end
+
+      # Dismisses an alert
+      # @param alert [Alert]
+      def dismiss_alert(alert)
+        logger.info "Dismissing alert ID #{alert.id}"
+        wait_for_load_and_click link_element(xpath: "//div[@id='alert-#{alert.id}']//a")
       end
 
       # Returns a user's SIS data visible on the student page

--- a/spec/boac/boac_alerts_spec.rb
+++ b/spec/boac/boac_alerts_spec.rb
@@ -1,0 +1,56 @@
+require_relative '../../util/spec_helper'
+
+describe 'A BOAC alert' do
+
+  include Logging
+
+  before(:all) do
+    @alert = BOACUtils.get_test_alert
+    @advisor = BOACUtils.get_authorized_users.find { |u| u.uid != Utils.super_admin_uid }
+    BOACUtils.remove_alert_dismissal(@alert) if BOACUtils.get_dismissed_alerts([@alert], @advisor).any?
+
+    @driver = Utils.launch_browser
+    @homepage = Page::BOACPages::HomePage.new @driver
+    @student_page = Page::BOACPages::StudentPage.new @driver
+    @homepage.dev_auth
+  end
+
+  after(:all) { Utils.quit_browser @driver }
+
+  context 'when not dismissed' do
+
+    before(:all) { @student_page.load_page @alert.user }
+
+    it('is shown by default on the student page') do
+      @student_page.wait_until(Utils.short_wait) { @student_page.non_dismissed_alert_msgs.include? @alert.message }
+    end
+  end
+
+  context 'when dismissed' do
+
+    before(:all) { @student_page.dismiss_alert @alert }
+
+    it 'is no longer shown by default' do
+      @student_page.wait_until(1) { !@student_page.non_dismissed_alert_msgs.include? @alert.message }
+      expect(@student_page.dismissed_alert_msgs).to include(@alert.message)
+      @student_page.wait_until(1) { !@student_page.dismissed_alert_msg_elements.any?(&:visible?) }
+    end
+
+    it 'can be revealed' do
+      @student_page.click_view_dismissed_alerts
+      @student_page.wait_until(1) { @student_page.dismissed_alert_msg_elements.all? &:visible? }
+    end
+
+    it 'can be hidden' do
+      @student_page.click_hide_dismissed_alerts
+      @student_page.wait_until(1) { !@student_page.dismissed_alert_msg_elements.any?(&:visible?) }
+    end
+
+    it 'is not dismissed for other users' do
+      @student_page.log_out
+      @homepage.dev_auth @advisor
+      @student_page.load_page @alert.user
+      @student_page.wait_until(Utils.short_wait) { @student_page.non_dismissed_alert_msgs.include? @alert.message }
+    end
+  end
+end


### PR DESCRIPTION
Dismissing, hiding, revealing alerts on the student page.  Still to come: alert visibility on the homepage.