### PR TITLE
Do not test events on recycled course sites

### DIFF
--- a/spec/suitec/asset_library_comments_spec.rb
+++ b/spec/suitec/asset_library_comments_spec.rb
@@ -236,7 +236,7 @@ describe 'An asset comment', order: :defined do
 
   describe 'events' do
 
-    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true unless ENV['COURSE_ID'] }
   end
 
 end

--- a/spec/suitec/asset_library_likes_spec.rb
+++ b/spec/suitec/asset_library_likes_spec.rb
@@ -156,7 +156,7 @@ describe 'Asset', order: :defined do
 
   describe 'events' do
 
-    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true unless ENV['COURSE_ID'] }
   end
 
 end

--- a/spec/suitec/asset_library_pins_spec.rb
+++ b/spec/suitec/asset_library_pins_spec.rb
@@ -333,7 +333,7 @@ describe 'Asset pinning', order: :defined do
 
   describe 'events' do
 
-    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true ENV['COURSE_ID'] }
   end
 
 end

--- a/spec/suitec/whiteboard_assets_spec.rb
+++ b/spec/suitec/whiteboard_assets_spec.rb
@@ -364,7 +364,7 @@ describe 'Whiteboard Add Asset', order: :defined do
 
   describe 'events' do
 
-    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true unless ENV['COURSE_ID'] }
   end
 
 end

--- a/spec/suitec/whiteboard_management_spec.rb
+++ b/spec/suitec/whiteboard_management_spec.rb
@@ -373,7 +373,7 @@ describe 'Whiteboard', order: :defined do
 
   describe 'events' do
 
-    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true }
+    it('record the right number of events') { expect(SuiteCUtils.events_match?(@course, event)).to be true unless ENV['COURSE_ID'] }
   end
 
 end


### PR DESCRIPTION
Recycled course sites already have a pile of events from previous test runs.