### PR TITLE
Flag tests that cannot run headless

### DIFF
--- a/pages/boac/student_page.rb
+++ b/pages/boac/student_page.rb
@@ -222,14 +222,14 @@ module Page
         grading_basis_xpath = "#{course_xpath}//span[contains(@class, 'profile-class-grading-basis')]"
         mid_point_grade_xpath = "#{course_xpath}//span[contains(@data-ng-bind,'course.midtermGrade')]"
         grade_xpath = "#{course_xpath}//span[contains(@data-ng-bind, 'course.grade')]"
-        wait_list_xpath = "#{course_xpath}//div[@data-ng-if='course.waitlisted']"
+        wait_list_xpath = "#{course_xpath}//span[@data-ng-if='course.waitlisted']"
         {
           :title => (h4_element(:xpath => title_xpath).text if h4_element(:xpath => title_xpath).exists?),
           :units => (div_element(:xpath => units_xpath).text.delete('Units').strip if div_element(:xpath => units_xpath).exists?),
           :grading_basis => (span_element(:xpath => grading_basis_xpath).text if (span_element(:xpath => grading_basis_xpath).exists? && !span_element(:xpath => grade_xpath).exists?)),
           :mid_point_grade => (span_element(:xpath => mid_point_grade_xpath).text if span_element(:xpath => mid_point_grade_xpath).exists?),
           :grade => (span_element(:xpath => grade_xpath).text if span_element(:xpath => grade_xpath).exists?),
-          :wait_list => (div_element(:xpath => wait_list_xpath).exists?)
+          :wait_list => (span_element(:xpath => wait_list_xpath).exists?)
         }
       end
 

--- a/spec/boac/boac_team_assignments_data_spec.rb
+++ b/spec/boac/boac_team_assignments_data_spec.rb
@@ -6,189 +6,195 @@ describe 'BOAC assignment analytics' do
 
   begin
 
-    team = BOACUtils.assignments_team
-    term_to_test = BOACUtils.analytics_term
+    if Utils.headless?
 
-    user_course_analytics_data = File.join(Utils.initialize_test_output_dir, 'boac-canvas-courses.csv')
-    user_analytics_data_heading = %w(UID Sport Term SiteCode SiteId
-                                      AssignMin AssignMax AssignUser AssignPerc AssignRound
-                                      GradesMin GradesMax GradesUser GradesPerc GradesRound)
-    CSV.open(user_course_analytics_data, 'wb') { |csv| csv << user_analytics_data_heading }
+      logger.warn 'This script requires admin Canvas access and cannot be run headless. Terminating.'
 
-    user_course_assigns = File.join(Utils.initialize_test_output_dir, 'boac-assignments.csv')
-    user_course_assigns_heading = %w(UID CanvasID Site AssignmentID URL DueDate Submission SubmitDate Type OnTime)
-    CSV.open(user_course_assigns, 'wb') { |csv| csv << user_course_assigns_heading }
+    else
+      team = BOACUtils.assignments_team
+      term_to_test = BOACUtils.analytics_term
 
-    @driver = Utils.launch_browser
-    @cal_net = Page::CalNetPage.new @driver
-    @canvas_assignments_page = Page::CanvasAssignmentsPage.new @driver
-    @canvas_discussions_page = Page::CanvasAnnounceDiscussPage.new @driver
-    @canvas_grades_page = Page::CanvasGradesPage.new @driver
-    @canvas_users_page = Page::CanvasPage.new @driver
-    @e_grades_page = Page::JunctionPages::CanvasEGradesExportPage.new @driver
-    @boac_homepage = Page::BOACPages::HomePage.new @driver
-    @boac_student_page = Page::BOACPages::StudentPage.new @driver
-    @boac_homepage.log_in(Utils.super_admin_username, Utils.super_admin_password, @cal_net)
+      user_course_analytics_data = File.join(Utils.initialize_test_output_dir, 'boac-canvas-courses.csv')
+      user_analytics_data_heading = %w(UID Sport Term SiteCode SiteId
+                                        AssignMin AssignMax AssignUser AssignPerc AssignRound
+                                        GradesMin GradesMax GradesUser GradesPerc GradesRound)
+      CSV.open(user_course_analytics_data, 'wb') { |csv| csv << user_analytics_data_heading }
 
-    BOACUtils.get_team_members(team).each do |student|
+      user_course_assigns = File.join(Utils.initialize_test_output_dir, 'boac-assignments.csv')
+      user_course_assigns_heading = %w(UID CanvasID Site AssignmentID URL DueDate Submission SubmitDate Type OnTime)
+      CSV.open(user_course_assigns, 'wb') { |csv| csv << user_course_assigns_heading }
 
-      boac_api_page = ApiUserAnalyticsPage.new @driver
-      boac_api_page.get_data(@driver, student)
-      boac_api_page.set_canvas_id student
-      term = boac_api_page.terms.find { |t| boac_api_page.term_name(t) == term_to_test }
+      @driver = Utils.launch_browser
+      @cal_net = Page::CalNetPage.new @driver
+      @canvas_assignments_page = Page::CanvasAssignmentsPage.new @driver
+      @canvas_discussions_page = Page::CanvasAnnounceDiscussPage.new @driver
+      @canvas_grades_page = Page::CanvasGradesPage.new @driver
+      @canvas_users_page = Page::CanvasPage.new @driver
+      @e_grades_page = Page::JunctionPages::CanvasEGradesExportPage.new @driver
+      @boac_homepage = Page::BOACPages::HomePage.new @driver
+      @boac_student_page = Page::BOACPages::StudentPage.new @driver
+      @boac_homepage.log_in(Utils.super_admin_username, Utils.super_admin_password, @cal_net)
 
-      if term
-        begin
+      BOACUtils.get_team_members(team).each do |student|
 
-          # Collect all the Canvas sites in the term, matched and unmatched
-          term_sites = []
-          term_sites << boac_api_page.unmatched_sites(term).map { |s| {:data => s} }
+        boac_api_page = ApiUserAnalyticsPage.new @driver
+        boac_api_page.get_data(@driver, student)
+        boac_api_page.set_canvas_id student
+        term = boac_api_page.terms.find { |t| boac_api_page.term_name(t) == term_to_test }
 
-          courses = boac_api_page.courses term
-          if courses.any?
-            courses.each do |course|
-              course_sites = boac_api_page.course_sites course
-              term_sites << course_sites.map { |s| {:data => s} }
+        if term
+          begin
+
+            # Collect all the Canvas sites in the term, matched and unmatched
+            term_sites = []
+            term_sites << boac_api_page.unmatched_sites(term).map { |s| {:data => s} }
+
+            courses = boac_api_page.courses term
+            if courses.any?
+              courses.each do |course|
+                course_sites = boac_api_page.course_sites course
+                term_sites << course_sites.map { |s| {:data => s} }
+              end
             end
-          end
 
-          term_sites.flatten.each do |site|
-            begin
+            term_sites.flatten.each do |site|
+              begin
 
-              site_data = site[:data]
-              site_code = boac_api_page.site_metadata(site_data)[:code]
-              site_id = boac_api_page.site_metadata(site_data)[:site_id]
-              course = Course.new({:site_id => site_id})
-              test_case = "Canvas ID #{student.canvas_id} UID #{student.uid} term #{term_to_test} course site ID #{site_id}, #{site_code}"
+                site_data = site[:data]
+                site_code = boac_api_page.site_metadata(site_data)[:code]
+                site_id = boac_api_page.site_metadata(site_data)[:site_id]
+                course = Course.new({:site_id => site_id})
+                test_case = "Canvas ID #{student.canvas_id} UID #{student.uid} term #{term_to_test} course site ID #{site_id}, #{site_code}"
 
-              logger.info "Checking site #{site_id}, #{site_code}"
+                logger.info "Checking site #{site_id}, #{site_code}"
 
-              # Gather the analytics data obtained from Nessie
-              boac_api_assigns_submitted = boac_api_page.nessie_assigns_submitted site_data
-              boac_api_grades = boac_api_page.nessie_grades site_data
+                # Gather the analytics data obtained from Nessie
+                boac_api_assigns_submitted = boac_api_page.nessie_assigns_submitted site_data
+                boac_api_grades = boac_api_page.nessie_grades site_data
 
-              if BOACUtils.nessie_assignments
+                if BOACUtils.nessie_assignments
 
-                logger.warn "Checking assignment submissions for #{test_case}"
+                  logger.warn "Checking assignment submissions for #{test_case}"
 
-                # Un-mute all assignments so that scores are visible to the student
-                @canvas_assignments_page.load_course_site(@driver, course)
-                @canvas_assignments_page.stop_masquerading(@driver) if @canvas_assignments_page.stop_masquerading_link?
-                @e_grades_page.resolve_all_issues(@driver, course)
-                @canvas_assignments_page.masquerade_as(@driver, student)
-                ui_assignments = @canvas_assignments_page.get_assignments(@driver, course, student, @canvas_discussions_page)
-                nessie_assignments = NessieUtils.get_assignments(student, course)
+                  # Un-mute all assignments so that scores are visible to the student
+                  @canvas_assignments_page.load_course_site(@driver, course)
+                  @canvas_assignments_page.stop_masquerading(@driver) if @canvas_assignments_page.stop_masquerading_link?
+                  @e_grades_page.resolve_all_issues(@driver, course)
+                  @canvas_assignments_page.masquerade_as(@driver, student)
+                  ui_assignments = @canvas_assignments_page.get_assignments(@driver, course, student, @canvas_discussions_page)
+                  nessie_assignments = NessieUtils.get_assignments(student, course)
 
-                if ui_assignments.any?
-                  # Compare the individual assignment data in Nessie with the same assignments in the Canvas UI
-                  it("has the right assignments for #{test_case}") { expect(ui_assignments.map(&:id).sort).to eql(nessie_assignments.map(&:id).sort) }
-                  ui_assignments.each do |ui|
-                    Utils.add_csv_row(user_course_assigns, [student.uid, student.canvas_id, site_id, ui.id, ui.url, ui.due_date, ui.submitted, ui.submission_date, ui.type, ui.on_time])
-                    nessie_assign = nessie_assignments.find { |n| n.id == ui.id }
-                    it("has the right assignment submission status for assignment ID #{ui.id} #{test_case}") { expect(nessie_assign.submitted).to eql(ui.submitted) }
+                  if ui_assignments.any?
+                    # Compare the individual assignment data in Nessie with the same assignments in the Canvas UI
+                    it("has the right assignments for #{test_case}") { expect(ui_assignments.map(&:id).sort).to eql(nessie_assignments.map(&:id).sort) }
+                    ui_assignments.each do |ui|
+                      Utils.add_csv_row(user_course_assigns, [student.uid, student.canvas_id, site_id, ui.id, ui.url, ui.due_date, ui.submitted, ui.submission_date, ui.type, ui.on_time])
+                      nessie_assign = nessie_assignments.find { |n| n.id == ui.id }
+                      it("has the right assignment submission status for assignment ID #{ui.id} #{test_case}") { expect(nessie_assign.submitted).to eql(ui.submitted) }
+                    end
+
+                    # Compare the total submitted assignment count in the BOAC API with the same assignment count in the Canvas UI
+                    submitted = ui_assignments.select &:submitted
+                    it("has the right Nessie assignments-submitted count for #{test_case}") { expect(boac_api_assigns_submitted[:score].to_i).to eql(submitted.length) }
+                  else
+                    logger.warn 'Either there are no assignments, or they are from a past semester and have been hidden in the UI.'
                   end
 
-                  # Compare the total submitted assignment count in the BOAC API with the same assignment count in the Canvas UI
-                  submitted = ui_assignments.select &:submitted
-                  it("has the right Nessie assignments-submitted count for #{test_case}") { expect(boac_api_assigns_submitted[:score].to_i).to eql(submitted.length) }
                 else
-                  logger.warn 'Either there are no assignments, or they are from a past semester and have been hidden in the UI.'
+                  logger.warn 'Skipping comparison of assignment submissions in Nessie versus Canvas UI'
                 end
 
-              else
-                logger.warn 'Skipping comparison of assignment submissions in Nessie versus Canvas UI'
-              end
+                if BOACUtils.nessie_scores
 
-              if BOACUtils.nessie_scores
+                  if boac_api_grades[:score].empty?
 
-                if boac_api_grades[:score].empty?
+                    logger.warn "Skipping current score tests for #{test_case}"
 
-                  logger.warn "Skipping current score tests for #{test_case}"
-
-                else
-
-                  logger.warn "Checking current score for #{test_case}"
-
-                  @canvas_grades_page.stop_masquerading(@driver) if @canvas_grades_page.stop_masquerading_link?
-                  @canvas_grades_page.load_gradebook course
-                  scores = @canvas_grades_page.export_grades course
-
-                  gradebook_min = scores.first
-                  logger.debug "Gradebook minimum current score: #{gradebook_min}"
-                  gradebook_min = gradebook_min[:score]
-                  it("has the same Canvas Gradebook and Nessie grades minimum for #{test_case}") { expect((gradebook_min.to_i - 1)..(gradebook_min.to_i + 1)).to include(boac_api_grades[:min].to_i) }
-
-                  gradebook_max = scores.last
-                  logger.debug "Gradebook maximum current score: #{gradebook_max}"
-                  gradebook_max = gradebook_max[:score]
-                  it("has the same Canvas Gradebook and Nessie grades maximum for #{test_case}") { expect((gradebook_max.to_i - 1)..(gradebook_max.to_i + 1)).to include(boac_api_grades[:max].to_i) }
-
-                  gradebook_user_score = (scores.find { |s| s[:uid] == student.uid })[:score]
-                  it("has the same Canvas Gradebook and Nessie grades user score for #{test_case}") { expect((gradebook_user_score.to_i - 1)..(gradebook_user_score.to_i + 1)).to include(boac_api_grades[:score].to_i) }
-                end
-
-              else
-                logger.warn 'Skipping comparison of current scores in Nessie versus Canvas UI'
-              end
-
-              if BOACUtils.tooltips
-
-                @boac_student_page.load_page student
-                @boac_student_page.click_view_previous_semesters if term_to_test != BOACUtils.term
-
-                # Find the site in the UI differently if it's matched versus unmatched
-                site[:course_code] ?
-                    (analytics_xpath = @boac_student_page.course_site_xpath(term_to_test, site[:course_code], site[:index])) :
-                    (analytics_xpath = @boac_student_page.unmatched_site_xpath(term_to_test, site_code))
-
-                [boac_api_assigns_submitted, boac_api_grades].each do |analytics|
-
-                  if analytics[:perc_round].nil?
-                    no_data = @boac_student_page.no_data?(analytics_xpath, analytics[:type])
-                    it("shows no '#{analytics[:type]}' data for #{test_case}") { expect(no_data).to be true }
                   else
-                    visible_analytics = case analytics[:type]
-                                          when 'Assignments Submitted'
-                                            @boac_student_page.visible_assignment_analytics(@driver, analytics_xpath, analytics)
-                                          when 'Assignment Grades'
-                                            @boac_student_page.visible_grades_analytics(@driver, analytics_xpath, analytics)
-                                          else
-                                            logger.error "Unsupported analytics type '#{analytics[:type]}'"
-                                        end
 
-                    it("shows the '#{analytics[:type]}' user percentile for #{test_case}") { expect(visible_analytics[:perc_round]).to eql(analytics[:perc_round]) }
-                    it("shows the '#{analytics[:type]}' user score for #{test_case}") { expect(visible_analytics[:score]).to eql(analytics[:score]) }
-                    it("shows the '#{analytics[:type]}' course maximum for #{test_case}") { expect(visible_analytics[:max]).to eql(analytics[:max]) }
+                    logger.warn "Checking current score for #{test_case}"
 
-                    if analytics[:graphable]
-                      it("shows the '#{analytics[:type]}' course 70th percentile for #{test_case}") { expect(visible_analytics[:perc_70]).to eql(analytics[:perc_70]) }
-                      it("shows the '#{analytics[:type]}' course 50th percentile for #{test_case}") { expect(visible_analytics[:perc_50]).to eql(analytics[:perc_50]) }
-                      it("shows the '#{analytics[:type]}' course 30th percentile for #{test_case}") { expect(visible_analytics[:perc_30]).to eql(analytics[:perc_30]) }
-                      it("shows the '#{analytics[:type]}' course minimum for #{test_case}") { expect(visible_analytics[:minimum]).to eql(analytics[:minimum]) }
+                    @canvas_grades_page.stop_masquerading(@driver) if @canvas_grades_page.stop_masquerading_link?
+                    @canvas_grades_page.load_gradebook course
+                    scores = @canvas_grades_page.export_grades course
+
+                    gradebook_min = scores.first
+                    logger.debug "Gradebook minimum current score: #{gradebook_min}"
+                    gradebook_min = gradebook_min[:score]
+                    it("has the same Canvas Gradebook and Nessie grades minimum for #{test_case}") { expect((gradebook_min.to_i - 1)..(gradebook_min.to_i + 1)).to include(boac_api_grades[:min].to_i) }
+
+                    gradebook_max = scores.last
+                    logger.debug "Gradebook maximum current score: #{gradebook_max}"
+                    gradebook_max = gradebook_max[:score]
+                    it("has the same Canvas Gradebook and Nessie grades maximum for #{test_case}") { expect((gradebook_max.to_i - 1)..(gradebook_max.to_i + 1)).to include(boac_api_grades[:max].to_i) }
+
+                    gradebook_user_score = (scores.find { |s| s[:uid] == student.uid })[:score]
+                    it("has the same Canvas Gradebook and Nessie grades user score for #{test_case}") { expect((gradebook_user_score.to_i - 1)..(gradebook_user_score.to_i + 1)).to include(boac_api_grades[:score].to_i) }
+                  end
+
+                else
+                  logger.warn 'Skipping comparison of current scores in Nessie versus Canvas UI'
+                end
+
+                if BOACUtils.tooltips
+
+                  @boac_student_page.load_page student
+                  @boac_student_page.click_view_previous_semesters if term_to_test != BOACUtils.term
+
+                  # Find the site in the UI differently if it's matched versus unmatched
+                  site[:course_code] ?
+                      (analytics_xpath = @boac_student_page.course_site_xpath(term_to_test, site[:course_code], site[:index])) :
+                      (analytics_xpath = @boac_student_page.unmatched_site_xpath(term_to_test, site_code))
+
+                  [boac_api_assigns_submitted, boac_api_grades].each do |analytics|
+
+                    if analytics[:perc_round].nil?
+                      no_data = @boac_student_page.no_data?(analytics_xpath, analytics[:type])
+                      it("shows no '#{analytics[:type]}' data for #{test_case}") { expect(no_data).to be true }
                     else
-                      it("shows no '#{analytics[:type]}' course 70th percentile for #{test_case}") { expect(visible_analytics[:perc_70]).to be_nil }
-                      it("shows no '#{analytics[:type]}' course 50th percentile for #{test_case}") { expect(visible_analytics[:perc_50]).to be_nil }
-                      it("shows no '#{analytics[:type]}' course 30th percentile for #{test_case}") { expect(visible_analytics[:perc_30]).to be_nil }
-                      it("shows no '#{analytics[:type]}' course minimum for #{test_case}") { expect(visible_analytics[:minimum]).to be_nil }
+                      visible_analytics = case analytics[:type]
+                                            when 'Assignments Submitted'
+                                              @boac_student_page.visible_assignment_analytics(@driver, analytics_xpath, analytics)
+                                            when 'Assignment Grades'
+                                              @boac_student_page.visible_grades_analytics(@driver, analytics_xpath, analytics)
+                                            else
+                                              logger.error "Unsupported analytics type '#{analytics[:type]}'"
+                                          end
+
+                      it("shows the '#{analytics[:type]}' user percentile for #{test_case}") { expect(visible_analytics[:perc_round]).to eql(analytics[:perc_round]) }
+                      it("shows the '#{analytics[:type]}' user score for #{test_case}") { expect(visible_analytics[:score]).to eql(analytics[:score]) }
+                      it("shows the '#{analytics[:type]}' course maximum for #{test_case}") { expect(visible_analytics[:max]).to eql(analytics[:max]) }
+
+                      if analytics[:graphable]
+                        it("shows the '#{analytics[:type]}' course 70th percentile for #{test_case}") { expect(visible_analytics[:perc_70]).to eql(analytics[:perc_70]) }
+                        it("shows the '#{analytics[:type]}' course 50th percentile for #{test_case}") { expect(visible_analytics[:perc_50]).to eql(analytics[:perc_50]) }
+                        it("shows the '#{analytics[:type]}' course 30th percentile for #{test_case}") { expect(visible_analytics[:perc_30]).to eql(analytics[:perc_30]) }
+                        it("shows the '#{analytics[:type]}' course minimum for #{test_case}") { expect(visible_analytics[:minimum]).to eql(analytics[:minimum]) }
+                      else
+                        it("shows no '#{analytics[:type]}' course 70th percentile for #{test_case}") { expect(visible_analytics[:perc_70]).to be_nil }
+                        it("shows no '#{analytics[:type]}' course 50th percentile for #{test_case}") { expect(visible_analytics[:perc_50]).to be_nil }
+                        it("shows no '#{analytics[:type]}' course 30th percentile for #{test_case}") { expect(visible_analytics[:perc_30]).to be_nil }
+                        it("shows no '#{analytics[:type]}' course minimum for #{test_case}") { expect(visible_analytics[:minimum]).to be_nil }
+                      end
                     end
                   end
                 end
-              end
 
-            rescue => e
-              Utils.log_error e
-              it("encountered an error with UID #{student.uid} #{test_case}") { fail }
-            ensure
-              row = [student.uid, team.name, term_to_test, site_code, site_id, boac_api_assigns_submitted[:min], boac_api_assigns_submitted[:max],
-                     boac_api_assigns_submitted[:score], boac_api_assigns_submitted[:perc], boac_api_assigns_submitted[:perc_round],
-                     boac_api_grades[:min], boac_api_grades[:max], boac_api_grades[:score], boac_api_grades[:perc], boac_api_grades[:perc_round]
-              ]
-              Utils.add_csv_row(user_course_analytics_data, row)
+              rescue => e
+                Utils.log_error e
+                it("encountered an error with UID #{student.uid} #{test_case}") { fail }
+              ensure
+                row = [student.uid, team.name, term_to_test, site_code, site_id, boac_api_assigns_submitted[:min], boac_api_assigns_submitted[:max],
+                       boac_api_assigns_submitted[:score], boac_api_assigns_submitted[:perc], boac_api_assigns_submitted[:perc_round],
+                       boac_api_grades[:min], boac_api_grades[:max], boac_api_grades[:score], boac_api_grades[:perc], boac_api_grades[:perc_round]
+                ]
+                Utils.add_csv_row(user_course_analytics_data, row)
+              end
             end
+          rescue => e
+            Utils.log_error e
+            it("encountered an error with UID #{student.uid} term #{term_to_test}") { fail }
           end
-        rescue => e
-          Utils.log_error e
-          it("encountered an error with UID #{student.uid} term #{term_to_test}") { fail }
         end
       end
     end

--- a/spec/boac/boac_team_last_activity_spec.rb
+++ b/spec/boac/boac_team_last_activity_spec.rb
@@ -6,192 +6,199 @@ describe 'BOAC' do
 
   begin
 
-    # This script is team-driven, so only an ASC advisor can be used
-    advisor = BOACUtils.get_dept_advisors(BOACDepartments::ASC).first
-    team = BOACUtils.last_activity_team
-    pages_tested = []
-    all_students = BOACUtils.get_all_athletes
-    team_members = BOACUtils.get_team_members(team, all_students)
-    term_to_test = BOACUtils.analytics_term
-    testable_users = []
-    logger.info "Checking term #{term_to_test}"
+    if Utils.headless?
 
-    last_activity_csv = Utils.create_test_output_csv('boac-last-activity', %w(Term CCN UID Canvas API ClassPage StudentPage))
+      logger.warn 'This script requires admin Canvas access and cannot be run headless. Terminating.'
 
-    @driver = Utils.launch_browser
-    @homepage = Page::BOACPages::HomePage.new @driver
-    @cal_net_page = Page::CalNetPage.new @driver
-    @canvas_page = Page::CanvasPage.new @driver
-    @class_page = Page::BOACPages::ClassPage.new @driver
-    @curated_page = Page::BOACPages::CohortPages::CuratedCohortListViewPage.new @driver
-    @student_page = Page::BOACPages::StudentPage.new @driver
+    else
+      # This script is team-driven, so only an ASC advisor can be used
+      advisor = BOACUtils.get_dept_advisors(BOACDepartments::ASC).first
+      team = BOACUtils.last_activity_team
+      pages_tested = []
+      all_students = BOACUtils.get_all_athletes
+      team_members = BOACUtils.get_team_members(team, all_students)
+      term_to_test = BOACUtils.analytics_term
+      testable_users = []
+      logger.info "Checking term #{term_to_test}"
 
-    @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password, 'https://bcourses.berkeley.edu')
-    @homepage.dev_auth advisor
+      last_activity_csv = Utils.create_test_output_csv('boac-last-activity', %w(Term CCN UID Canvas API ClassPage StudentPage))
 
-    team_members.each do |athlete|
+      @driver = Utils.launch_browser
+      @homepage = Page::BOACPages::HomePage.new @driver
+      @cal_net_page = Page::CalNetPage.new @driver
+      @canvas_page = Page::CanvasPage.new @driver
+      @class_page = Page::BOACPages::ClassPage.new @driver
+      @curated_page = Page::BOACPages::CohortPages::CuratedCohortListViewPage.new @driver
+      @student_page = Page::BOACPages::StudentPage.new @driver
 
-      begin
+      @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password, 'https://bcourses.berkeley.edu')
+      @homepage.dev_auth advisor
 
-        # Get the user API data for the athlete to determine which courses to check
-        api_athlete_page = ApiUserAnalyticsPage.new @driver
-        api_athlete_page.get_data(@driver, athlete)
+      team_members.each do |athlete|
 
-        term = api_athlete_page.terms.find { |t| api_athlete_page.term_name(t) == term_to_test }
+        begin
 
-        if term
-          term_id = api_athlete_page.term_id term
+          # Get the user API data for the athlete to determine which courses to check
+          api_athlete_page = ApiUserAnalyticsPage.new @driver
+          api_athlete_page.get_data(@driver, athlete)
 
-          api_athlete_page.courses(term).each do |course|
+          term = api_athlete_page.terms.find { |t| api_athlete_page.term_name(t) == term_to_test }
 
-            course_sis_data = api_athlete_page.course_sis_data course
-            unless course_sis_data[:code].include? 'PHYS ED'
-              logger.info "Checking course #{course_sis_data[:code]}"
+          if term
+            term_id = api_athlete_page.term_id term
 
-                api_athlete_page.sections(course).each do |section|
+            api_athlete_page.courses(term).each do |course|
 
-                # If the section is primary and hasn't been checked already, collect all the student data for the section
-                begin
-                  section_data = api_athlete_page.section_sis_data section
-                  if api_athlete_page.section_sis_data(section)[:primary] && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
-                    pages_tested << "#{term_id} #{section_data[:ccn]}"
+              course_sis_data = api_athlete_page.course_sis_data course
+              unless course_sis_data[:code].include? 'PHYS ED'
+                logger.info "Checking course #{course_sis_data[:code]}"
 
-                    api_section_page = ApiSectionPage.new @driver
-                    api_section_page.get_data(@driver, term_id, section_data[:ccn])
+                  api_athlete_page.sections(course).each do |section|
 
-                    all_student_data = []
-                    section_students = all_students.select { |s| api_section_page.student_uids.include? s.uid }
-                    section_students.each do |student|
+                  # If the section is primary and hasn't been checked already, collect all the student data for the section
+                  begin
+                    section_data = api_athlete_page.section_sis_data section
+                    if api_athlete_page.section_sis_data(section)[:primary] && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
+                      pages_tested << "#{term_id} #{section_data[:ccn]}"
 
-                      # Collect all the Canvas sites associated with that student in that course and the last activity data in BOAC's API data
-                      begin
-                        api_student_page = ApiUserAnalyticsPage.new @driver
-                        api_student_page.get_data(@driver, student)
-                        term = api_student_page.terms.find { |t| api_student_page.term_name(t) == term_to_test }
-                        student_course = api_student_page.courses(term).find { |c| api_student_page.course_display_name(c) == course_sis_data[:code] }
-                        sites = api_student_page.course_sites student_course
+                      api_section_page = ApiSectionPage.new @driver
+                      api_section_page.get_data(@driver, term_id, section_data[:ccn])
 
-                        # Load the student page for the student, and collect all the last activity info shown for each relevant site
-                        @student_page.load_page student
-                        @student_page.click_view_previous_semesters if term_to_test != BOACUtils.term
-                        sleep 2
-                        @student_page.expand_course_data(term_to_test, course_sis_data[:code])
+                      all_student_data = []
+                      section_students = all_students.select { |s| api_section_page.student_uids.include? s.uid }
+                      section_students.each do |student|
 
-                        student_data = {
-                          :student => student,
-                          :sites => (sites.map do |site|
-                            {
-                              :site_id => api_student_page.site_metadata(site)[:site_id],
-                              :site_code => api_student_page.site_metadata(site)[:code],
-                              :last_activity_api => api_student_page.nessie_last_activity(site),
-                              :last_activity_student_page => @student_page.visible_last_activity(term_to_test, course_sis_data[:code], sites.index(site))
-                            }
-                          end)
-                        }
-                        all_student_data << student_data
+                        # Collect all the Canvas sites associated with that student in that course and the last activity data in BOAC's API data
+                        begin
+                          api_student_page = ApiUserAnalyticsPage.new @driver
+                          api_student_page.get_data(@driver, student)
+                          term = api_student_page.terms.find { |t| api_student_page.term_name(t) == term_to_test }
+                          student_course = api_student_page.courses(term).find { |c| api_student_page.course_display_name(c) == course_sis_data[:code] }
+                          sites = api_student_page.course_sites student_course
+
+                          # Load the student page for the student, and collect all the last activity info shown for each relevant site
+                          @student_page.load_page student
+                          @student_page.click_view_previous_semesters if term_to_test != BOACUtils.term
+                          sleep 2
+                          @student_page.expand_course_data(term_to_test, course_sis_data[:code])
+
+                          student_data = {
+                            :student => student,
+                            :sites => (sites.map do |site|
+                              {
+                                :site_id => api_student_page.site_metadata(site)[:site_id],
+                                :site_code => api_student_page.site_metadata(site)[:code],
+                                :last_activity_api => api_student_page.nessie_last_activity(site),
+                                :last_activity_student_page => @student_page.visible_last_activity(term_to_test, course_sis_data[:code], sites.index(site))
+                              }
+                            end)
+                          }
+                          all_student_data << student_data
+                        end
                       end
-                    end
 
-                    # Load the class page for the section, and collect all the last activity info shown for each student + site
-                    @class_page.load_page(term_id, section_data[:ccn])
-                    all_student_data.each do |d|
-                      d[:sites].each do |s|
-                        index = d[:sites].index s
-                        last_activity = @class_page.visible_last_activity(d[:student], index)[:last_activity]
-                        s.merge!(:last_activity_class_page => last_activity)
+                      # Load the class page for the section, and collect all the last activity info shown for each student + site
+                      @class_page.load_page(term_id, section_data[:ccn])
+                      all_student_data.each do |d|
+                        d[:sites].each do |s|
+                          index = d[:sites].index s
+                          last_activity = @class_page.visible_last_activity(d[:student], index)[:last_activity]
+                          s.merge!(:last_activity_class_page => last_activity)
+                        end
                       end
-                    end
 
-                    all_sites_ids = all_student_data.map do |d|
-                      d[:sites].map { |s| s[:site_id] }
-                    end
-                    unique_site_ids = all_sites_ids.flatten.uniq
-                    logger.info "Canvas course site IDs associated with this course are #{unique_site_ids}"
+                      all_sites_ids = all_student_data.map do |d|
+                        d[:sites].map { |s| s[:site_id] }
+                      end
+                      unique_site_ids = all_sites_ids.flatten.uniq
+                      logger.info "Canvas course site IDs associated with this course are #{unique_site_ids}"
 
-                    testable_users << athlete if unique_site_ids.any?
+                      testable_users << athlete if unique_site_ids.any?
 
-                    # For each student in each site, compare the last activity date shown in the Canvas UI with the date shown on BOAC pages
-                    unique_site_ids.each do |site_id|
+                      # For each student in each site, compare the last activity date shown in the Canvas UI with the date shown on BOAC pages
+                      unique_site_ids.each do |site_id|
 
-                      begin
-                        logger.debug "Checking site ID #{site_id}"
-                        @canvas_page.load_all_students(Course.new({:site_id => site_id}), 'https://bcourses.berkeley.edu')
+                        begin
+                          logger.debug "Checking site ID #{site_id}"
+                          @canvas_page.load_all_students(Course.new({:site_id => site_id}), 'https://bcourses.berkeley.edu')
 
-                        all_student_data.each do |d|
+                          all_student_data.each do |d|
 
-                          begin
-                            test_case = "UID #{d[:student].uid} in Canvas site ID #{site_id}"
-                            logger.debug "Checking last activity in Canvas for #{test_case}"
-                            d[:sites].each do |s|
+                            begin
+                              test_case = "UID #{d[:student].uid} in Canvas site ID #{site_id}"
+                              logger.debug "Checking last activity in Canvas for #{test_case}"
+                              d[:sites].each do |s|
 
-                              if s[:site_id] == site_id
-                                canvas_last_activity = @canvas_page.roster_user_last_activity d[:student].uid
-                                Utils.add_csv_row(last_activity_csv, [term_to_test, site_id, d[:student].uid, canvas_last_activity, s[:last_activity_api], s[:last_activity_class_page], s[:last_activity_student_page]])
+                                if s[:site_id] == site_id
+                                  canvas_last_activity = @canvas_page.roster_user_last_activity d[:student].uid
+                                  Utils.add_csv_row(last_activity_csv, [term_to_test, site_id, d[:student].uid, canvas_last_activity, s[:last_activity_api], s[:last_activity_class_page], s[:last_activity_student_page]])
 
-                                if canvas_last_activity.empty?
-                                  it("shows null Last Activity in the BOAC API for #{test_case}") { expect(s[:last_activity_api]).to be_nil }
-                                  it("shows 'Never' Last Activity in the BOAC class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql('Never') }
-                                  it("shows 'never' Last Activity in the BOAC student page for #{test_case}") { expect(s[:last_activity_student_page]).to include('never') }
-
-                                else
-
-                                  day_count = ((Time.now.utc - Time.parse(canvas_last_activity).utc) / (24 * 60 * 60)).floor
-
-                                  if day_count.zero?
-                                    logger.warn "Skipping last activity check for #{test_case}, since the user visited the site today and BOAC will not know that."
+                                  if canvas_last_activity.empty?
+                                    it("shows null Last Activity in the BOAC API for #{test_case}") { expect(s[:last_activity_api]).to be_nil }
+                                    it("shows 'Never' Last Activity in the BOAC class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql('Never') }
+                                    it("shows 'never' Last Activity in the BOAC student page for #{test_case}") { expect(s[:last_activity_student_page]).to include('never') }
 
                                   else
-                                    it("shows #{day_count} days since Last Activity in the BOAC API for #{test_case}") { expect(s[:last_activity_api]).to eql(day_count) }
 
-                                    if day_count == 1
-                                      it("shows 'Yesterday' Last Activity on the class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql('Yesterday') }
-                                      it("shows 'Yesterday' Last Activity on the student page for #{test_case}") { expect(s[:last_activity_student_page]).to eql('Yesterday') }
+                                    day_count = ((Time.now.utc - Time.parse(canvas_last_activity).utc) / (24 * 60 * 60)).floor
+
+                                    if day_count.zero?
+                                      logger.warn "Skipping last activity check for #{test_case}, since the user visited the site today and BOAC will not know that."
+
                                     else
-                                      it("shows '#{day_count} days ago' Last Activity on the class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql("#{day_count} days ago") }
-                                      it("shows '#{day_count} days ago' Last Activity on the student page for #{test_case}") { expect(s[:last_activity_student_page]).to eql("#{day_count} days ago") }
+                                      it("shows #{day_count} days since Last Activity in the BOAC API for #{test_case}") { expect(s[:last_activity_api]).to eql(day_count) }
+
+                                      if day_count == 1
+                                        it("shows 'Yesterday' Last Activity on the class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql('Yesterday') }
+                                        it("shows 'Yesterday' Last Activity on the student page for #{test_case}") { expect(s[:last_activity_student_page]).to eql('Yesterday') }
+                                      else
+                                        it("shows '#{day_count} days ago' Last Activity on the class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql("#{day_count} days ago") }
+                                        it("shows '#{day_count} days ago' Last Activity on the student page for #{test_case}") { expect(s[:last_activity_student_page]).to eql("#{day_count} days ago") }
+                                      end
                                     end
                                   end
+                                else
+                                  logger.debug "UID #{d[:student].uid} is not associated with site ID #{site_id}"
                                 end
-                              else
-                                logger.debug "UID #{d[:student].uid} is not associated with site ID #{site_id}"
                               end
+                            rescue => e
+                              Utils.log_error e
+                              it("hit an error with #{test_case}") { fail }
                             end
-                          rescue => e
-                            Utils.log_error e
-                            it("hit an error with #{test_case}") { fail }
                           end
-                        end
 
-                      rescue => e
-                        Utils.log_error e
-                        it("hit an error with site #{site_id}") { fail }
+                        rescue => e
+                          Utils.log_error e
+                          it("hit an error with site #{site_id}") { fail }
+                        end
                       end
                     end
-                  end
 
-                rescue => e
-                  Utils.log_error e
-                  it("hit an error with term #{term_to_test} CCN #{section_data[:ccn]}") { fail }
+                  rescue => e
+                    Utils.log_error e
+                    it("hit an error with term #{term_to_test} CCN #{section_data[:ccn]}") { fail }
+                  end
                 end
               end
             end
+          else
+            logger.warn "UID #{athlete.uid} has no enrollments in #{term_to_test}"
           end
-        else
-          logger.warn "UID #{athlete.uid} has no enrollments in #{term_to_test}"
-        end
 
-      rescue => e
-        Utils.log_error e
-        it("hit an error with team UID #{athlete.uid}") { fail }
+        rescue => e
+          Utils.log_error e
+          it("hit an error with team UID #{athlete.uid}") { fail }
+        end
+      end
+
+      if testable_users.empty?
+        it("has nothing with which to test Last Activity for team #{team.code}") { fail }
       end
     end
-
-    if testable_users.empty?
-      it("has nothing with which to test Last Activity for team #{team.code}") { fail }
-    end
-
   rescue => e
     Utils.log_error e
     it('hit an error') { fail }
+  ensure
+    Utils.quit_browser @driver
   end
 end

--- a/util/utils.rb
+++ b/util/utils.rb
@@ -49,7 +49,7 @@ class Utils
           profile_dir = (profile ? profile : File.join(@config_dir, 'chrome-profile'))
           options.add_argument("user-data-dir=#{profile_dir}")
         end
-        options.add_argument 'headless' if driver_config['headless']
+        options.add_argument 'headless' if headless?
         prefs = {
             :prompt_for_download => false,
             :default_directory => Utils.download_dir
@@ -66,7 +66,7 @@ class Utils
         # Turn off Firefox's pretty JSON since it prevents parsing JSON strings in the browser.
         profile['devtools.jsonview.enabled'] = false
         options = Selenium::WebDriver::Firefox::Options.new(:profile => profile)
-        options.add_argument '-headless' if driver_config['headless']
+        options.add_argument '-headless' if headless?
         driver = Selenium::WebDriver.for :firefox, :options => options
 
       when 'safari'
@@ -91,6 +91,10 @@ class Utils
 
   def self.optional_chrome_profile_dir
     File.join(@config_dir, 'chrome-profile-optional')
+  end
+
+  def self.headless?
+    @config['webdriver']['headless']
   end
 
   # @param driver [Selenium::WebDriver]


### PR DESCRIPTION
Mostly indentation change... if a BOAC script requires admin Canvas access but is set to run headlessly, the script will now abort.