### PR TITLE
Support CoE in filtered cohort tests

### DIFF
--- a/models/boac/boac_departments.rb
+++ b/models/boac/boac_departments.rb
@@ -8,7 +8,7 @@ class BOACDepartments
 
   DEPARTMENTS = [
       ASC = new('UWASC'),
-      COE = new('EHEEC')
+      COE = new('COENG')
   ]
 
 end

--- a/models/boac/filtered_cohort.rb
+++ b/models/boac/filtered_cohort.rb
@@ -1,6 +1,6 @@
 class FilteredCohort < Cohort
 
-  attr_accessor :search_criteria, :member_count
+  attr_accessor :search_criteria, :member_count, :read_only
 
   def initialize(cohort_data)
     cohort_data.each { |k, v| public_send("#{k}=", v) }

--- a/pages/boac/filtered_cohort_list_view_page.rb
+++ b/pages/boac/filtered_cohort_list_view_page.rb
@@ -20,7 +20,7 @@ module Page
         # @return [Array<String>]
         def expected_sids_by_first_name(user_data, search_criteria)
           expected_users = expected_search_results(user_data, search_criteria)
-          sorted_users = expected_users.sort_by { |u| [u[:first_name_sortable].downcase, u[:last_name_sortable].downcase, u[:sid]] }
+          sorted_users = expected_users.sort_by { |u| [u[:first_name].downcase, u[:last_name].downcase, u[:sid]] }
           sorted_users.map { |u| u[:sid] }
         end
 
@@ -30,7 +30,7 @@ module Page
         # @return [Array<String>]
         def expected_sids_by_last_name(user_data, search_criteria)
           expected_users = expected_search_results(user_data, search_criteria)
-          sorted_users = expected_users.sort_by { |u| [u[:last_name_sortable].downcase, u[:first_name_sortable].downcase, u[:sid]] }
+          sorted_users = expected_users.sort_by { |u| [u[:last_name].downcase, u[:first_name].downcase, u[:sid]] }
           sorted_users.map { |u| u[:sid] }
         end
 
@@ -40,7 +40,7 @@ module Page
         # @return [Array<String>]
         def expected_sids_by_team(user_data, search_criteria)
           expected_users = expected_search_results(user_data, search_criteria)
-          sorted_users = expected_users.sort_by { |u| [u[:squad_names].sort.first.gsub(/\W/, ''), u[:last_name_sortable], u[:first_name_sortable]] }
+          sorted_users = expected_users.sort_by { |u| [u[:squad_names].sort.first, u[:last_name].downcase, u[:first_name].downcase] }
           sorted_users.map { |u| u[:sid] }
         end
 
@@ -50,7 +50,7 @@ module Page
         # @return [Array<String>]
         def expected_sids_by_gpa(user_data, search_criteria)
           expected_users = expected_search_results(user_data, search_criteria)
-          sorted_users = expected_users.sort_by { |u| [u[:gpa].to_f, u[:last_name_sortable], u[:first_name_sortable]] }
+          sorted_users = expected_users.sort_by { |u| [u[:gpa].to_f, u[:last_name].downcase, u[:first_name].downcase] }
           sorted_users.map { |u| u[:sid] }
         end
 
@@ -61,7 +61,7 @@ module Page
         def expected_sids_by_level(user_data, search_criteria)
           expected_users = expected_search_results(user_data, search_criteria)
           # Sort first by the secondary sort order
-          users_by_first_name = expected_users.sort_by { |u| [u[:last_name_sortable], u[:first_name_sortable]] }
+          users_by_first_name = expected_users.sort_by { |u| [u[:last_name].downcase, u[:first_name].downcase] }
           # Then arrange by the sort order for level
           users_by_level = []
           %w(Freshman Sophomore Junior Senior Graduate).each do |level|
@@ -78,7 +78,7 @@ module Page
         # @return [Array<String>]
         def expected_sids_by_major(user_data, search_criteria)
           expected_users = expected_search_results(user_data, search_criteria)
-          sorted_users = expected_users.sort_by { |u| [u[:majors].sort.first.downcase.gsub(/\s+/, ''), u[:last_name_sortable], u[:first_name_sortable]] }
+          sorted_users = expected_users.sort_by { |u| [u[:majors].sort.first, u[:last_name].downcase, u[:first_name].downcase] }
           sorted_users.map { |u| u[:sid] }
         end
 
@@ -88,7 +88,7 @@ module Page
         # @return [Array<String>]
         def expected_sids_by_units(user_data, search_criteria)
           expected_users = expected_search_results(user_data, search_criteria)
-          sorted_users = expected_users.sort_by { |u| [u[:units].to_f, u[:last_name_sortable], u[:first_name_sortable]] }
+          sorted_users = expected_users.sort_by { |u| [u[:units].to_f, u[:last_name].downcase, u[:first_name].downcase] }
           sorted_users.map { |u| u[:sid] }
         end
 

--- a/settings.yml
+++ b/settings.yml
@@ -44,7 +44,6 @@ boac:
   db_user: secret
   db_password: secret
   tooltips: true
-  nessie_students_data: false
   nessie_scores: true
   nessie_assignments: true
   canvas_data_lag_days: 1
@@ -100,11 +99,6 @@ nessie:
   db_name: secret
   db_user: secret
   db_password: secret
-  rds_host: secret
-  rds_port: secret
-  rds_name: secret
-  rds_user: secret
-  rds_password: secret
 
 oec:
   term: 2018-C

--- a/spec/boac/boac_team_assignments_data_spec.rb
+++ b/spec/boac/boac_team_assignments_data_spec.rb
@@ -33,7 +33,7 @@ describe 'BOAC assignment analytics' do
       @boac_student_page = Page::BOACPages::StudentPage.new @driver
       @boac_homepage.log_in(Utils.super_admin_username, Utils.super_admin_password, @cal_net)
 
-      all_team_members = BOACUtils.get_team_members(team)
+      all_team_members = NessieUtils.get_asc_team_members team
       BOACUtils.assignments_max_users(all_team_members).each do |student|
 
         boac_api_page = ApiUserAnalyticsPage.new @driver

--- a/spec/boac/boac_team_class_pages_spec.rb
+++ b/spec/boac/boac_team_class_pages_spec.rb
@@ -11,8 +11,8 @@ describe 'BOAC' do
     team = BOACUtils.class_page_team
 
     pages_tested = []
-    all_students = BOACUtils.get_all_athletes
-    team_members = BOACUtils.get_team_members(team, all_students)
+    students = NessieUtils.get_all_asc_students
+    team_members = NessieUtils.get_asc_team_members(team, students)
 
     courses_csv = Utils.create_test_output_csv('boac-class-page-courses.csv', %w(Term Course Title Format Units))
     meetings_csv =Utils.create_test_output_csv('boac-class-page-meetings.csv', %w(Term Course Instructors Days Time Location))
@@ -118,7 +118,7 @@ describe 'BOAC' do
                           it("shows the right students for #{class_test_case}") { expect(visible_sids.sort).to eql(api_section_page.student_sids.sort) }
 
                           # Perform further tests on the students who do appear
-                          students = all_students.select { |s| visible_sids.include? s.sis_id }
+                          students = students.select { |s| visible_sids.include? s.sis_id }
                           expected_student_names = (students.map { |u| "#{u.last_name}, #{u.first_name}" }).sort
                           visible_student_names = (@class_page.list_view_names).sort
                           logger.error "Expecting #{expected_student_names} and got #{visible_student_names}" unless visible_student_names == expected_student_names

--- a/spec/boac/boac_team_curated_cohort_spec.rb
+++ b/spec/boac/boac_team_curated_cohort_spec.rb
@@ -10,7 +10,7 @@ describe 'BOAC', order: :defined do
   other_advisor = BOACUtils.get_authorized_users.find { |u| u.uid != advisor.uid }
   pre_existing_cohorts = BOACUtils.get_user_curated_cohorts advisor
   team = BOACUtils.curated_cohort_team
-  students = BOACUtils.get_team_members(team).delete_if { |s| s.status == 'inactive' }
+  students = NessieUtils.get_asc_team_members(team).delete_if { |s| s.status == 'inactive' }
 
   before(:all) do
     @driver = Utils.launch_browser

--- a/spec/boac/boac_team_last_activity_spec.rb
+++ b/spec/boac/boac_team_last_activity_spec.rb
@@ -15,8 +15,8 @@ describe 'BOAC' do
       advisor = BOACUtils.get_dept_advisors(BOACDepartments::ASC).first
       team = BOACUtils.last_activity_team
       pages_tested = []
-      all_students = BOACUtils.get_all_athletes
-      team_members = BOACUtils.get_team_members(team, all_students)
+      students = NessieUtils.get_all_asc_students
+      team_members = NessieUtils.get_asc_team_members(team, students)
 
       # Test Last Activity using the current term rather than past term
       term_to_test = BOACUtils.term
@@ -69,7 +69,7 @@ describe 'BOAC' do
                       api_section_page.get_data(@driver, term_id, section_data[:ccn])
 
                       all_student_data = []
-                      section_students = all_students.select { |s| api_section_page.student_uids.include? s.uid }
+                      section_students = students.select { |s| api_section_page.student_uids.include? s.uid }
                       section_students.each do |student|
 
                         # Collect all the Canvas sites associated with that student in that course and the last activity data in BOAC's API data

--- a/spec/boac/boac_team_sis_data_spec.rb
+++ b/spec/boac/boac_team_sis_data_spec.rb
@@ -10,7 +10,7 @@ describe 'BOAC' do
     advisor = BOACUtils.get_dept_advisors(BOACDepartments::ASC).first
 
     # Get all teams and get the one for testing
-    teams = BOACUtils.get_teams
+    teams = NessieUtils.get_asc_teams
     team = BOACUtils.sis_data_team teams
 
     # Create files for test output
@@ -36,7 +36,7 @@ describe 'BOAC' do
     if visible_team_names.include? team.name
       begin
 
-        team_members = BOACUtils.get_team_members(team).sort_by! &:full_name
+        team_members = NessieUtils.get_asc_team_members(team).sort_by! &:full_name
         logger.debug "There are #{team_members.length} total athletes"
         team_members.delete_if { |u| u.status == 'inactive' }
         logger.debug "There are #{team_members.length} active athletes"

--- a/spec/boac/boac_team_user_search_spec.rb
+++ b/spec/boac/boac_team_user_search_spec.rb
@@ -5,7 +5,7 @@ describe 'BOAC' do
   include Logging
 
   team = BOACUtils.user_search_team
-  athletes = BOACUtils.get_team_members team
+  athletes = NessieUtils.get_asc_team_members team
   active_athletes = athletes.select { |a| a.status == 'active' }
   inactive_athlete = athletes.find { |a| a.status == 'inactive' }
 


### PR DESCRIPTION
- Moves student database queries to Nessie
- Handles different student populations in filtered cohort searches
- Temporarily removes inactive, intensive, etc tests, which will move to a new script
- Removes RDS support