### PR TITLE
Fix SuiteC CSV tests

### DIFF
--- a/pages/suitec/engagement_index_page.rb
+++ b/pages/suitec/engagement_index_page.rb
@@ -398,7 +398,7 @@ module Page
         load_scores(driver, url, event)
         window = driver.window_handle
         window_count = driver.window_handles.length
-        wait_for_load_and_click_js download_csv_link_element
+        navigate_to "#{SuiteCUtils.suite_c_base_url}/api/#{Utils.canvas_base_url.gsub('https://', '')}/#{course.site_id}/activities.csv"
         date = Time.now.strftime('%Y_%m_%d')
         # Hour and minute in the file name are globbed to avoid test failures due to clock sync issues
         csv_file_path = "#{Utils.download_dir}/engagement_index_activities_#{course.site_id}_#{date}_*.csv"


### PR DESCRIPTION
SuiteC's CSV download link kills the latest version of Chrome when run by ChromeDriver.