### PR TITLE
Overhaul activity tests to include alerts

### DIFF
--- a/models/boac/boac_test_config.rb
+++ b/models/boac/boac_test_config.rb
@@ -102,7 +102,6 @@ class BOACTestConfig < TestConfig
     set_default_cohort(CONFIG['curated_cohort_team'], CONFIG['curated_cohort_max_users'])
     if @dept == BOACDepartments::COE
       @cohort_members = @cohort_members[0..49]
-      @default_cohort.name = 'My Students'
     elsif @dept == BOACDepartments::ASC
       @cohort_members.keep_if &:active_asc
     end

--- a/pages/boac/api_section_page.rb
+++ b/pages/boac/api_section_page.rb
@@ -23,12 +23,33 @@ class ApiSectionPage
     end
   end
 
+  def students
+    @parsed['students']
+  end
+
   def student_sids
-    @parsed['students'] && @parsed['students'].map { |s| s['sid'] }
+    students && students.map { |s| s['sid'] }
   end
 
   def student_uids
-    @parsed['students'] && @parsed['students'].map { |s| s['uid'] }
+    students && students.map { |s| s['uid'] }
+  end
+
+  def student_enrollment(student)
+    student['enrollment']
+  end
+
+  def student_sites(student)
+    student_enrollment(student) && student_enrollment(student)['canvasSites']
+  end
+
+  def site_id(site)
+    site['canvasCourseId']
+  end
+
+  def student_site_ids(student)
+    api_student = students.find { |s| s['uid'] == student.uid }
+    api_student && student_sites(api_student).map { |site| site_id site }
   end
 
 end

--- a/pages/boac/api_user_analytics_page.rb
+++ b/pages/boac/api_user_analytics_page.rb
@@ -60,7 +60,7 @@ class ApiUserAnalyticsPage
       :phone => (sis_profile && sis_profile['phoneNumber'].to_s),
       :units_in_progress => (sis_profile && ((current_term ? formatted_units(current_term['enrolledUnits']) : '0') if terms.any?)),
       :cumulative_units => (sis_profile && formatted_units(sis_profile['cumulativeUnits'])),
-      :cumulative_gpa => (sis_profile && (sis_profile['cumulativeGPA'] == 0 ? '--' : sis_profile['cumulativeGPA'].to_s)),
+      :cumulative_gpa => (sis_profile && (sis_profile['cumulativeGPA'] == 0 ? '--' : (sprintf '%.3f', sis_profile['cumulativeGPA']).to_s)),
       :majors => (sis_profile && majors),
       :colleges => (sis_profile && colleges),
       :level => (sis_profile && (sis_profile['level'] && sis_profile['level']['description'])),
@@ -162,6 +162,10 @@ class ApiUserAnalyticsPage
       courses = enrolled_courses.map { |c| course_sis_data(c)[:code] }
     end
     courses
+  end
+
+  def course_section_ccns(course)
+    sections(course).map { |s| section_sis_data(s)[:ccn] }
   end
 
   def dropped_sections(term)

--- a/pages/boac/class_list_view_page.rb
+++ b/pages/boac/class_list_view_page.rb
@@ -60,7 +60,7 @@ module Page
         # @param node [Integer]
         # @return [String]
         def site_code(student, node)
-          el = div_element(xpath: "(#{list_view_user_xpath student}//span[@data-ng-bind=\"canvasSite.courseCode\"])[#{node}]")
+          el = div_element(xpath: "(#{list_view_user_xpath student}//strong[@data-ng-bind=\"canvasSite.courseCode\"])[#{node}]")
           el.text if el.exists?
         end
 
@@ -154,9 +154,10 @@ module Page
         # @return [Hash]
         def visible_last_activity(student, index)
           node = index + 1
+          wait_until(Utils.short_wait) { site_code(student, node) }
           {
             :site_code => site_code(student, node),
-            :last_activity => last_activity(student, node)
+            :days => last_activity(student, node)
           }
         end
 

--- a/pages/boac/cohort_pages.rb
+++ b/pages/boac/cohort_pages.rb
@@ -35,7 +35,7 @@ module Page
       # @param user [User]
       # @return [String]
       def list_view_user_gpa(driver, user)
-        el = driver.find_element(xpath: "#{list_view_user_xpath user}//div[contains(@data-ng-bind,'student.cumulativeGPA')]")
+        el = driver.find_element(xpath: "#{list_view_user_xpath user}//span[contains(@data-ng-bind,'student.cumulativeGPA')]")
         el && el.text
       end
 
@@ -72,7 +72,7 @@ module Page
       # @return [Hash]
       def visible_sis_data(driver, user)
         wait_until(Utils.medium_wait) { player_link_elements.any? }
-        sleep 1
+        wait_until(Utils.short_wait) { list_view_user_level(user) }
         {
           :level => list_view_user_level(user),
           :majors => list_view_user_majors(driver, user),

--- a/pages/boac/student_page.rb
+++ b/pages/boac/student_page.rb
@@ -414,7 +414,9 @@ module Page
       def visible_days_since(term_name, course_code, index)
         # Look first for days since last activity
         begin
-          span_element(:xpath => "#{course_site_xpath(term_name, course_code, index)}//td[contains(.,\"Last bCourses Activity\")]/following-sibling::td//span[2]").text
+          xpath = "#{course_site_xpath(term_name, course_code, index)}//td[contains(.,\"Last bCourses Activity\")]/following-sibling::td//span[2]"
+          span_element(:xpath => xpath).when_visible(Utils.click_wait)
+          span_element(:xpath => xpath).text
         # If no days-since exists, check for 'never'
         rescue
           el = div_element(:xpath => "#{course_site_xpath(term_name, course_code, index)}//td[contains(.,\"Last bCourses Activity\")]/following-sibling::td/div")
@@ -438,10 +440,10 @@ module Page
       # @param index [Integer]
       # @return [Hash]
       def visible_last_activity(term_name, course_code, index)
-        sleep 1
+        wait_until(Utils.short_wait) { visible_days_since(term_name, course_code, index) }
         {
-          :last_activity => visible_days_since(term_name, course_code, index),
-          :activity_context => visible_activity_context(term_name, course_code, index)
+          :days => visible_days_since(term_name, course_code, index),
+          :context => visible_activity_context(term_name, course_code, index)
         }
       end
 

--- a/pages/page.rb
+++ b/pages/page.rb
@@ -195,6 +195,7 @@ module Page
   # Uses JavaScript to scroll to the bottom of a page. This is a workaround for a WebDriver bug where certain elements
   # are not scrolled into focus prior to an interaction.
   def scroll_to_bottom
+    sleep Utils.click_wait
     execute_script 'window.scrollTo(0, document.body.scrollHeight);'
   end
 

--- a/settings.yml
+++ b/settings.yml
@@ -62,6 +62,7 @@ boac:
 
   last_activity_team: TNM
   last_activity_max_users: 3
+  last_activity_context: false
 
   navigation_team: FBM
 

--- a/spec/boac/boac_curated_cohort_spec.rb
+++ b/spec/boac/boac_curated_cohort_spec.rb
@@ -175,9 +175,9 @@ describe 'BOAC', order: :defined do
     end
 
     it 'can be added from filtered cohort list view using individual selections' do
-      test.cohort_members.pop
       @filtered_page.load_cohort test.default_cohort
-      @filtered_page.selector_add_students_to_curated(test.cohort_members, @cohort_2)
+      @filtered_page.selector_add_students_to_curated(test.cohort_members[0..-2], @cohort_2)
+      test.cohort_members.pop
     end
 
     it 'can be added on the student page using the curated cohort box' do

--- a/spec/boac/boac_last_activity_spec.rb
+++ b/spec/boac/boac_last_activity_spec.rb
@@ -18,184 +18,262 @@ describe 'BOAC' do
 
       # Test Last Activity using the current term rather than past term
       test.term = BOACUtils.term
-      testable_users = []
       logger.info "Checking term #{test.term}"
 
-      last_activity_csv = Utils.create_test_output_csv('boac-last-activity.csv', %w(Term CCN UID Canvas ClassPageActivity StudentPageActivity StudentPageContext))
+      last_activity_csv = Utils.create_test_output_csv('boac-last-activity.csv', %w(Term Course SiteId TtlStudents TtlLogins UID CanvasLastActivity StudentPageActivity CanvasContext StudentPageContext))
 
       @driver = Utils.launch_browser
       @homepage = Page::BOACPages::HomePage.new @driver
       @cal_net_page = Page::CalNetPage.new @driver
       @canvas_page = Page::CanvasPage.new @driver
-      @class_page = Page::BOACPages::ClassPages::ClassListViewPage.new @driver
       @curated_page = Page::BOACPages::CohortPages::CuratedCohortPage.new @driver
       @student_page = Page::BOACPages::StudentPage.new @driver
 
       @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password, 'https://bcourses.berkeley.edu')
       @homepage.dev_auth test.advisor
 
-      test.max_cohort_members.each do |student|
-
+      test.max_cohort_members.each do |test_student|
         begin
 
-          # Get the user API data for the athlete to determine which courses to check
-          api_athlete_page = ApiUserAnalyticsPage.new @driver
-          api_athlete_page.get_data(@driver, student)
-
-          term = api_athlete_page.terms.find { |t| api_athlete_page.term_name(t) == test.term }
-
+          # Get the user API data for the test student to determine which courses to check
+          api_student_page = ApiUserAnalyticsPage.new @driver
+          api_student_page.get_data(@driver, test_student)
+          term = api_student_page.terms.find { |t| api_student_page.term_name(t) == test.term }
           if term
-            term_id = api_athlete_page.term_id term
+            term_id = api_student_page.term_id term
 
-            api_athlete_page.courses(term).each do |course|
+            api_student_page.courses(term).each do |course|
 
-              course_sis_data = api_athlete_page.course_sis_data course
+              course_sis_data = api_student_page.course_sis_data course
+              logger.info "Checking course #{course_sis_data[:code]}"
 
-              # Skip PHYS ED sites for now, since the rosters are large and they rarely have active course sites
-              unless course_sis_data[:code].include? 'PHYS ED'
-                logger.info "Checking course #{course_sis_data[:code]}"
+              api_student_page.sections(course).each do |section|
+                begin
 
-                  api_athlete_page.sections(course).each do |section|
+                  # Only test a primary section that hasn't been tested already
+                  section_data = api_student_page.section_sis_data section
+                  if api_student_page.section_sis_data(section)[:primary] && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
+                    pages_tested << "#{term_id} #{section_data[:ccn]}"
 
-                  # If the section is primary and hasn't been checked already, collect all the student data for the section
-                  begin
-                    section_data = api_athlete_page.section_sis_data section
-                    if api_athlete_page.section_sis_data(section)[:primary] && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
-                      pages_tested << "#{term_id} #{section_data[:ccn]}"
+                    # Get all the students in the course who will be visible in BOAC
+                    api_section_page = ApiSectionPage.new @driver
+                    api_section_page.get_data(@driver, term_id, section_data[:ccn])
+                    visible_classmates = test.dept_students.select { |s| api_section_page.student_uids.include? s.uid }
 
-                      api_section_page = ApiSectionPage.new @driver
-                      api_section_page.get_data(@driver, term_id, section_data[:ccn])
+                    # Only test courses with sites
+                    if api_section_page.student_site_ids(visible_classmates.first).any?
 
-                      all_student_data = []
-                      section_students = test.dept_students.select { |s| api_section_page.student_uids.include? s.uid }
-                      section_students.each do |section_student|
+                      visible_student_data = []
+                      all_sites_data = []
 
-                        # Collect all the Canvas sites associated with that student in that course and the last activity data in BOAC's API data
+                      # Collect all the Canvas sites associated with each student who's visible in BOAC
+                      visible_classmates.each do |classmate|
                         begin
-                          api_student_page = ApiUserAnalyticsPage.new @driver
-                          api_student_page.get_data(@driver, section_student)
-                          term = api_student_page.terms.find { |t| api_student_page.term_name(t) == test.term }
-                          student_course = api_student_page.courses(term).find { |c| api_student_page.course_display_name(c) == course_sis_data[:code] }
-                          sites = api_student_page.course_sites student_course
 
-                          # Load the student page for the student, and collect all the last activity info shown for each relevant site
-                          @student_page.load_page section_student
-                          @student_page.click_view_previous_semesters if test.term != BOACUtils.term
-                          sleep 2
-                          @student_page.expand_course_data(test.term, course_sis_data[:code])
-
-                          student_data = {
-                            :student => section_student,
-                            :sites => (sites.map do |site|
+                          api_classmate_page = ApiUserAnalyticsPage.new @driver
+                          api_classmate_page.get_data(@driver, classmate)
+                          term = api_classmate_page.terms.find { |t| api_classmate_page.term_name(t) == test.term }
+                          classmate_course = api_classmate_page.courses(term).find { |c| api_classmate_page.course_section_ccns(c).include? section_data[:ccn] }
+                          classmate_section = api_classmate_page.sections(classmate_course).find { |s| api_classmate_page.section_sis_data(s)[:ccn] == section_data[:ccn] }
+                          classmate_sites = api_classmate_page.course_sites classmate_course
+                          classmate_data = {
+                            :student => classmate,
+                            :course_code => api_classmate_page.course_display_name(classmate_course),
+                            :section_format => "#{api_classmate_page.section_sis_data(classmate_section)[:component]} #{api_classmate_page.section_sis_data(classmate_section)[:number]}",
+                            :sites => (classmate_sites.map do |site|
                               {
                                 :site_id => api_student_page.site_metadata(site)[:site_id],
-                                :site_code => api_student_page.site_metadata(site)[:code],
-                                :last_activity_student_page => @student_page.visible_last_activity(test.term, course_sis_data[:code], sites.index(site))
+                                :site_code => api_student_page.site_metadata(site)[:code]
                               }
                             end)
                           }
-                          all_student_data << student_data
+                          visible_student_data << classmate_data
                         end
                       end
 
-                      # Load the class page for the section, and collect all the last activity info shown for each student + site
-                      @class_page.load_page(term_id, section_data[:ccn])
-                      all_student_data.each do |d|
+                      # Get the unique sites associated with the course
+                      site_ids = visible_student_data.map { |d| d[:sites].map { |s| s[:site_id] } }
+                      site_ids.flatten!
+                      site_ids.uniq!
+                      logger.info "Canvas course site IDs associated with this course are #{site_ids}"
+
+                      # Load the student page for each student, and collect all the last activity info shown for each site
+                      visible_student_data.each do |d|
+                        @student_page.load_page d[:student]
+                        @student_page.scroll_to_bottom
+                        @student_page.expand_course_data(test.term, d[:course_code])
                         d[:sites].each do |s|
-                          index = d[:sites].index s
-                          last_activity = @class_page.visible_last_activity(d[:student], index)[:last_activity]
-                          s.merge!(:last_activity_class_page => last_activity)
+                          s.merge!(:last_activity_student_page => @student_page.visible_last_activity(test.term, d[:course_code], d[:sites].index(s)))
                         end
                       end
 
-                      all_sites_ids = all_student_data.map do |d|
-                        d[:sites].map { |s| s[:site_id] }
+                      # Load each course site, and collect the last activity shown for every student visible in BOAC
+                      site_ids.each do |site_id|
+                        all_site_students = @canvas_page.get_students(Course.new({:site_id => site_id}), nil, 'https://bcourses.berkeley.edu')
+                        visible_student_data.each do |student_data|
+                          if (student_data[:sites].map { |s| s[:site_id] }).include? site_id
+                            student_last_activity = @canvas_page.roster_user_last_activity student_data[:student].uid
+                            site_to_update = student_data[:sites].find { |site| site[:site_id] == site_id }
+                            site_to_update.merge!(:last_activity_canvas => (Time.parse student_last_activity if student_last_activity))
+                          end
+                        end
+
+                        # Collect the last activity shown for students not visible in BOAC
+                        invisible_student_site_data = []
+                        invisible_students = all_site_students.reject { |student| test.dept_students.map(&:uid).include? student.uid }
+                        invisible_students.each do |invisible_student|
+                          last_activity = @canvas_page.roster_user_last_activity invisible_student.uid
+                          student_data = {
+                            :student => invisible_student,
+                            :sites => [
+                              {
+                                :site_id => site_id,
+                                :last_activity_canvas => (Time.parse last_activity if last_activity)
+                              }
+                            ]
+                          }
+                          invisible_student_site_data << student_data
+                        end
+
+                        # Aggregate the Canvas data for the site
+                        all_last_activities = all_site_students.map do |student|
+                          student_data = (visible_student_data + invisible_student_site_data).find { |data| data[:student].uid == student.uid }
+                          site = student_data[:sites].find { |s| s[:site_id] == site_id }
+                          site[:last_activity_canvas]
+                        end
+                        all_site_data = {
+                          :site_id => site_id,
+                          :student_count => all_site_students.length,
+                          :last_activity_dates => all_last_activities
+                        }
+                        all_sites_data << all_site_data
                       end
-                      unique_site_ids = all_sites_ids.flatten.uniq
-                      logger.info "Canvas course site IDs associated with this course are #{unique_site_ids}"
 
-                      testable_users << student if unique_site_ids.any?
-
-                      # For each student in each site, compare the last activity date shown in the Canvas UI with the date shown on BOAC pages
-                      unique_site_ids.each do |site_id|
-
+                      visible_student_data.each do |student_data|
                         begin
-                          logger.debug "Checking site ID #{site_id}"
-                          total_students = @canvas_page.load_all_students(Course.new({:site_id => site_id}), 'https://bcourses.berkeley.edu')
 
-                          all_student_data.each do |d|
+                          student_data[:sites].each do |student_site|
 
-                            begin
-                              test_case = "UID #{d[:student].uid} in Canvas site ID #{site_id}"
-                              logger.debug "Checking last activity in Canvas for #{test_case}"
-                              d[:sites].each do |s|
+                            test_case = "UID #{student_data[:student].uid} in Canvas site ID #{student_site[:site_id]}"
+                            logger.info "Checking last activity for #{test_case}"
 
-                                if s[:site_id] == site_id
-                                  canvas_last_activity = @canvas_page.roster_user_last_activity d[:student].uid
-                                  Utils.add_csv_row(last_activity_csv, [test.term, site_id, d[:student].uid, canvas_last_activity, s[:last_activity_class_page], s[:last_activity_student_page][:last_activity], s[:last_activity_student_page][:activity_context]])
+                            # Record the activity data to a CSV
+                            logger.debug "Last activity in Canvas site #{student_site[:site_id]} is #{student_site[:last_activity_canvas]}"
+                            site = all_sites_data.find { |s| s[:site_id] == student_site[:site_id] }
+                            total_logins = site[:last_activity_dates].compact.length
+                            more_recent_logins = student_site[:last_activity_canvas] ? site[:last_activity_dates].compact.select { |date| date > student_site[:last_activity_canvas] } : []
 
-                                  if canvas_last_activity.empty?
-                                    it("shows 'Never' Last Activity in the BOAC class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql('Never') }
-                                    it("shows 'never' Last Activity in the BOAC student page for #{test_case}") { expect(s[:last_activity_student_page][:last_activity]).to include('never') }
+                            data_to_record = [test.term, course_sis_data[:code], site[:site_id], site[:last_activity_dates].length, total_logins,
+                                              student_data[:student].uid, student_site[:last_activity_canvas], student_site[:last_activity_student_page][:days],
+                                              (("#{more_recent_logins.length} out of #{site[:last_activity_dates].length} enrolled students have done so more recently.") if more_recent_logins),
+                                              student_site[:last_activity_student_page][:context]]
+                            Utils.add_csv_row(last_activity_csv, data_to_record)
 
-                                  else
+                            # SITE DETAIL
 
-                                    day_count = (Date.today - Date.parse(canvas_last_activity)).to_i
+                            if student_site[:last_activity_canvas].nil?
+                              it("shows 'never' Last Activity in the BOAC student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to include('never') }
 
-                                    if day_count < BOACUtils.canvas_data_lag_days
-                                      logger.warn "Skipping last activity check for #{test_case}, since the user visited the site within day count #{day_count}, and BOAC will not know that."
+                              # Note if the site could trigger a 'no activity' alert
+                              # TODO - account for 'start of session'
+                              student_site.merge!(:no_activity_alert => true) if total_logins.to_f / site[:last_activity_dates].length.to_f >= 0.8
 
-                                    else
+                            else
 
-                                      if day_count == 1
-                                        it("shows 'Yesterday' Last Activity on the class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql('Yesterday') }
-                                        it("shows 'yesterday' Last Activity on the student page for #{test_case}") { expect(s[:last_activity_student_page][:last_activity]).to eql('yesterday') }
-                                      else
-                                        it("shows '#{day_count} days ago' Last Activity on the class page for #{test_case}") { expect(s[:last_activity_class_page]).to eql("#{day_count} days ago") }
-                                        it("shows '#{day_count} days ago' Last Activity on the student page for #{test_case}") { expect(s[:last_activity_student_page][:last_activity]).to eql("#{day_count} days ago") }
-                                      end
+                              day_count = (Date.today - Date.parse(student_site[:last_activity_canvas].to_s)).to_i
+                              if day_count < BOACUtils.canvas_data_lag_days
+                                logger.warn "Skipping last activity check for #{test_case}, since the user visited the site within day count #{day_count}, and BOAC will not know that."
 
-                                      it("shows #{total_students} total students for #{test_case}") { expect(s[:last_activity_student_page][:activity_context]).to include("out of #{total_students} enrolled students") }
-                                    end
-                                  end
-                                else
-                                  logger.debug "UID #{d[:student].uid} is not associated with site ID #{site_id}"
+                              else
+
+                                (day_count == 1) ?
+                                    (it("shows 'yesterday' Last Activity on the student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to eql('yesterday') }) :
+                                    (it("shows '#{day_count} days ago' Last Activity on the student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to eql("#{day_count} days ago") })
+
+                                if BOACUtils.last_activity_context
+                                  it("shows #{site[:last_activity_dates].length} total students for #{test_case}") { expect(student_site[:last_activity_student_page][:context]).to include("out of #{site[:last_activity_dates].length} enrolled students") }
                                 end
                               end
-                            rescue => e
-                              Utils.log_error e
-                              it("hit an error with #{test_case}") { fail }
+
+                              # Note if the site could trigger an 'infrequent activity' alert
+                              student_site.merge!(:infrequent_activity_alert => true) if (day_count >= 14) && (more_recent_logins.length.to_f / site[:last_activity_dates].length.to_f >= 0.8)
+
+                            end
+                          end
+
+                          # ALERTS
+
+                          # To verify that an inactivity alert does NOT exist, compare without the 'x days' portion of the alerts
+                          user_alert_msgs = BOACUtils.get_students_alerts([student_data[:student]]).map &:message
+                          truncated_alert_msgs = user_alert_msgs.map { |msg| msg.gsub(/( was )\d+( days ago.)/, '') }
+                          logger.debug "UID #{student_data[:student].uid} alerts: #{user_alert_msgs}"
+
+                          test_case = "UID #{student_data[:student].uid} in #{student_data[:course_code]}"
+                          logger.debug "Checking #{test_case}"
+
+                          # Never show alerts for DeCal courses
+                          if (student_data[:section_format] == /\w+\s1?9[89][A-Z]?[A-Z]?/) && !student_data[:section_format].include?('LEC')
+                            it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
+                            it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
+
+                          else
+                            # Alerts are not shown for sites below an activity threshold, so get the student's 'active' sites
+                            active_student_sites = student_data[:sites].select do |student_site|
+                              course_site = all_sites_data.find { |course_site| course_site[:site_id] == student_site[:site_id]}
+                              (course_site[:last_activity_dates].compact.length.to_f / course_site[:student_count].to_f > 0.8)
+                            end
+
+                            # Get the sites that could trigger an alert
+                            infrequent_alert_triggers = active_student_sites.select { |site| site[:infrequent_activity_alert] }
+                            no_activity_alert_triggers = active_student_sites.select { |site| site[:no_activity_alert] }
+
+                            # If all the active sites could trigger 'no activity' alerts for the student, then show a 'no activity' alert
+                            if no_activity_alert_triggers.length == active_student_sites.length
+                              it("shows a 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
+                              it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
+
+                            # If all the active sites could trigger an alert and some could trigger an 'infrequent activity' alert,
+                            # then show an 'infrequent' alert for the one with the most recent activity
+                            elsif infrequent_alert_triggers.any? && (no_activity_alert_triggers.length + infrequent_alert_triggers.length == active_student_sites.length)
+                              most_recent = infrequent_alert_triggers.max_by { |site| site[:last_activity_canvas] }
+                              day_count = (Date.today - Date.parse(most_recent[:last_activity_canvas].to_s)).to_i
+                              it("shows an infrequent activity alert for #{test_case}") { expect(user_alert_msgs).to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity was #{day_count} days ago.") }
+                              it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
+
+                            else
+                              it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
+                              it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
                             end
                           end
 
                         rescue => e
                           Utils.log_error e
-                          it("hit an error with site #{site_id}") { fail }
+                          it("hit an error with #{student_data[:student].uid}") { fail }
                         end
                       end
-                    end
 
-                  rescue => e
-                    Utils.log_error e
-                    it("hit an error with term #{test.term} CCN #{section_data[:ccn]}") { fail }
+                    else
+                      logger.warn "There are no Canvas sites to check for term #{test.term} CCN #{section_data[:ccn]}, skipping"
+                    end
                   end
+
+                rescue => e
+                  Utils.log_error e
+                  it("hit an error with term #{test.term} CCN #{section_data[:ccn]}") { fail }
                 end
               end
             end
           else
-            logger.warn "UID #{student.uid} has no enrollments in #{test.term}"
+            logger.warn "UID #{test_student.uid} has no enrollments in #{test.term}"
           end
 
         rescue => e
           Utils.log_error e
-          it("hit an error with #{test.default_cohort.name} UID #{student.uid}") { fail }
+          it("hit an error with #{test.default_cohort.name} UID #{test_student.uid}") { fail }
         end
       end
-
-      if testable_users.empty?
-        it("has nothing with which to test Last Activity for #{test.default_cohort.name}") { fail }
-      end
     end
+
   rescue => e
     Utils.log_error e
     it('hit an error') { fail }

--- a/spec/boac/boac_user_role_coe_spec.rb
+++ b/spec/boac/boac_user_role_coe_spec.rb
@@ -33,7 +33,7 @@ describe 'A CoE advisor using BOAC' do
     all_student_search_data = @api_user_analytics_page.users_searchable_data
     unless all_student_search_data
       @homepage.dev_auth
-      test.dept_students.keep_if &:active_asc if test.dept == BOACDepartments::ASC
+      test_asc.dept_students.keep_if &:active_asc if test_asc.dept == BOACDepartments::ASC
       all_student_search_data = @api_user_analytics_page.collect_users_searchable_data(@driver, all_students)
 
       @homepage.load_page

--- a/spec/junction/canvas_lti_e_grades_api_spec.rb
+++ b/spec/junction/canvas_lti_e_grades_api_spec.rb
@@ -36,7 +36,7 @@ describe 'bCourses E-Grades Export' do
         @e_grades_export_page.resolve_all_issues(@driver, course)
 
         # Get grades in Canvas
-        students = @canvas.get_enrolled_students(course, primary_section)
+        students = @canvas.get_students(course, primary_section)
         @canvas.load_gradebook course
         @canvas.click_gradebook_settings
         grades_are_final = @canvas.gradebook_include_ungraded_checked?

--- a/util/boac_utils.rb
+++ b/util/boac_utils.rb
@@ -66,6 +66,11 @@ class BOACUtils < Utils
     @config['canvas_data_lag_days']
   end
 
+  # Whether or not to compare student data to fellow cohort members in Canvas prod
+  def self.last_activity_context
+    @config['last_activity_context']
+  end
+
   # Logs error, prints stack trace, and saves a screenshot when running headlessly
   def self.log_error_and_screenshot(driver, error, unique_id)
     log_error error
@@ -148,7 +153,7 @@ class BOACUtils < Utils
   # @return [Array<FilteredCohort>]
   def self.get_user_filtered_cohorts(user)
     query = "SELECT cohort_filters.id AS cohort_id,
-                    cohort_filters.label AS cohort_name,
+                    cohort_filters.name AS cohort_name,
                     cohort_filters.filter_criteria AS criteria
               FROM cohort_filters
               JOIN cohort_filter_owners ON cohort_filter_owners.cohort_filter_id = cohort_filters.id
@@ -166,7 +171,7 @@ class BOACUtils < Utils
   # @return [Array<FilteredCohort>]
   def self.get_everyone_filtered_cohorts(dept = nil)
     query = "SELECT cohort_filters.id AS cohort_id,
-                    cohort_filters.label AS cohort_name,
+                    cohort_filters.name AS cohort_name,
                     cohort_filters.filter_criteria AS criteria,
                     authorized_users.uid AS uid
               FROM cohort_filters
@@ -189,7 +194,7 @@ class BOACUtils < Utils
   def self.set_filtered_cohort_id(cohort)
     query = "SELECT id
              FROM cohort_filters
-             WHERE label = '#{cohort.name}'"
+             WHERE name = '#{cohort.name}'"
     result = Utils.query_pg_db_field(boac_db_credentials, query, 'id').first
     logger.info "Filtered cohort '#{cohort.name}' ID is #{result}"
     cohort.id = result


### PR DESCRIPTION
Script now checks the last activity data against Canvas and checks whether or not an alert should be shown.  The latter is a useful way to determine how many stale (i.e., no longer valid) alerts are present.

Includes misc bug fixes elsewhere.