### PR TITLE
SIS tests can finally run for non-athletes

### DIFF
--- a/models/boac/boac_test_config.rb
+++ b/models/boac/boac_test_config.rb
@@ -39,8 +39,7 @@ class BOACTestConfig < TestConfig
 
   # Sets an existing cohort to use for testing, e.g., a team for ASC and admin or My Students for CoE
   # @param team_config [String]
-  # @param max_users_config [Integer]
-  def set_default_cohort(team_config, max_users_config = nil)
+  def set_default_cohort(team_config)
     case @dept
       # For CoE, use the advisor's assigned students
       when BOACDepartments::COE
@@ -58,9 +57,14 @@ class BOACTestConfig < TestConfig
     end
 
     @default_cohort.name = "Default cohort #{@id}"
-    @default_cohort.member_count = @cohort_members.length if @cohort_members
-    @max_cohort_members = @cohort_members[0..(max_users_config - 1)] if max_users_config
+    @default_cohort.member_count = @cohort_members.length
     @term = BOACUtils.assignments_term
+  end
+
+  # Selects only the first n cohort members for testing
+  # @param config [Integer]
+  def set_max_cohort_members(config)
+    @max_cohort_members = @cohort_members.sort_by(&:last_name)[0..(config - 1)]
   end
 
   # Configures a set of cohorts to use for filtered cohort testing
@@ -85,22 +89,25 @@ class BOACTestConfig < TestConfig
   # @param all_students [Array<BOACUser>]
   def assignments(all_students)
     set_global_configs all_students
-    set_default_cohort(CONFIG['assignments_team'], CONFIG['assignments_max_users'])
+    set_default_cohort CONFIG['assignments_team']
+    set_max_cohort_members CONFIG['assignments_max_users']
   end
 
   # Config for class page testing
   # @param all_students [Array<BOACUser>]
   def class_pages(all_students)
     set_global_configs all_students
-    set_default_cohort(CONFIG['class_page_team'], CONFIG['class_page_max_users'])
+    set_default_cohort CONFIG['class_page_team']
+    set_max_cohort_members CONFIG['class_page_max_users']
   end
 
   # Config for curated cohort testing
   # @param all_students [Array<BOACUser>]
   def curated_cohorts(all_students)
     set_global_configs all_students
-    set_default_cohort(CONFIG['curated_cohort_team'], CONFIG['curated_cohort_max_users'])
+    set_default_cohort CONFIG['curated_cohort_team']
     @cohort_members.keep_if &:active_asc if @dept == BOACDepartments::ASC
+    set_max_cohort_members CONFIG['curated_cohort_max_users']
   end
 
   # Config for filtered cohort testing
@@ -135,21 +142,25 @@ class BOACTestConfig < TestConfig
   # @param all_students [Array<BOACUser>]
   def last_activity(all_students)
     set_global_configs all_students
-    set_default_cohort(CONFIG['last_activity_team'], CONFIG['last_activity_max_users'])
+    set_default_cohort CONFIG['last_activity_team']
+    set_max_cohort_members CONFIG['last_activity_max_users']
   end
 
   # Config for page navigation testing
   # @param all_students [Array<BOACUser>]
   def navigation(all_students)
     set_global_configs all_students
-    set_default_cohort(CONFIG['class_page_team'], CONFIG['class_page_max_users'])
+    set_default_cohort CONFIG['class_page_team']
+    set_max_cohort_members CONFIG['class_page_max_users']
   end
 
   # Config for SIS data testing
   # @param all_students [Array<BOACUser>]
-  def team_sis_data(all_students)
-    set_global_configs(all_students, BOACDepartments::ASC)
-    set_default_cohort(CONFIG['sis_data_team'])
+  def sis_data(all_students)
+    set_global_configs all_students
+    set_default_cohort CONFIG['sis_data_team']
+    @cohort_members.keep_if &:active_asc if @dept == BOACDepartments::ASC
+    set_max_cohort_members CONFIG['sis_data_max_users']
   end
 
   # Config for admin user role testing
@@ -178,7 +189,9 @@ class BOACTestConfig < TestConfig
   # @param all_students [Array<BOACUser>]
   def user_search(all_students)
     set_global_configs all_students
-    set_default_cohort(CONFIG['user_search_team'], CONFIG['user_search_max_users'])
+    set_default_cohort CONFIG['user_search_team']
+    @cohort_members.keep_if &:active_asc if @dept == BOACDepartments::ASC
+    set_max_cohort_members CONFIG['user_search_max_users']
   end
 
 end

--- a/pages/boac/boac_pages.rb
+++ b/pages/boac/boac_pages.rb
@@ -364,6 +364,7 @@ module Page
     # @return [Array<String>]
     def list_view_sids
       wait_until(Utils.medium_wait) { player_link_elements.any? }
+      sleep Utils.click_wait
       player_sid_elements.map { |el| el.text.gsub(/(INACTIVE)/, '').gsub(/(WAITLISTED)/, '').strip }
     end
 

--- a/pages/boac/home_page.rb
+++ b/pages/boac/home_page.rb
@@ -198,8 +198,8 @@ module Page
           # Verify that there is a row for each student with a positive alert count and that the alert count is right
           cohort.member_data.each do |member|
             logger.debug "Checking cohort row for SID #{member[:sid]}"
-            wait_until(1, "Expecting alert count #{member[:alert_count]}, got #{user_row_data(driver, member, cohort)[:alert_count]}") do
-              user_row_data(driver, member, cohort)[:alert_count] == member[:alert_count].to_s
+            wait_until(1, "Expecting alert count #{member[:alert_count]}, got #{user_row_data(driver, member[:sid], cohort)[:alert_count]}") do
+              user_row_data(driver, member[:sid], cohort)[:alert_count] == member[:alert_count].to_s
             end
           end
         end

--- a/pages/boac/search_results_page.rb
+++ b/pages/boac/search_results_page.rb
@@ -28,6 +28,12 @@ module Page
         elements(:student_row, :div, xpath: '//div[contains(@data-ng-repeat,"student in students")]')
         elements(:student_row_sid, :div, xpath: '//div[contains(@data-ng-repeat,"student in students")]//span[@data-ng-bind="student.sid"]')
 
+        # Returns the result count for a student search
+        # @return [Integer]
+        def student_search_results_count
+          results_count student_results_count_element
+        end
+
         # Returns all the SIDs displayed on the page
         # @return [Array<String>]
         def student_row_sids

--- a/spec/boac/boac_filtered_cohort_spec.rb
+++ b/spec/boac/boac_filtered_cohort_spec.rb
@@ -47,7 +47,9 @@ describe 'BOAC', order: :defined do
         cohort.member_data = @cohort_page.expected_search_results(searchable_students, cohort.search_criteria)
         expected_results = @cohort_page.expected_sids_by_last_name cohort.member_data
         visible_results = cohort.member_count.zero? ? [] : @cohort_page.visible_sids
-        @cohort_page.wait_until(1, "Expected but not present: #{expected_results - visible_results}. Present but not expected: #{visible_results - expected_results}") { visible_results.sort == expected_results.sort }
+        @cohort_page.wait_until(1, "Expected but not present: #{expected_results - visible_results}. Present but not expected: #{visible_results - expected_results}") do
+          visible_results.sort == expected_results.sort
+        end
         @cohort_page.verify_list_view_sorting(expected_results, visible_results)
       end
 
@@ -210,7 +212,7 @@ describe 'BOAC', order: :defined do
       it "allows the advisor to sort by term units ascending cohort members who have alerts on the homepage with criteria #{cohort.search_criteria.list_filters}" do
         if cohort.member_data.any?
           # Scrape the visible term units since it's not stored in the cohort member data
-          cohort.member_data.each { |d| d.merge!({:term_units => @homepage.user_row_data(@driver, d, cohort)[:term_units]}) }
+          cohort.member_data.each { |d| d.merge!({:term_units => @homepage.user_row_data(@driver, d[:sid], cohort)[:term_units]}) }
           expected_sequence = @homepage.expected_sids_by_term_units cohort.member_data
           @homepage.sort_by_term_units cohort
           @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids(@driver, cohort)}") { @homepage.all_row_sids(@driver, cohort) == expected_sequence }

--- a/spec/boac/boac_team_sis_data_spec.rb
+++ b/spec/boac/boac_team_sis_data_spec.rb
@@ -5,13 +5,9 @@ include Logging
 describe 'BOAC' do
 
   begin
-
     test = BOACTestConfig.new
     all_students = NessieUtils.get_all_students
-    test.team_sis_data all_students
-    teams = NessieUtils.get_asc_teams
-    team = Team::TEAMS.find { |t| t.code == BOACUtils.sis_data_team }
-    test.default_cohort.name = team.name
+    test.sis_data all_students
 
     # Create files for test output
     user_profile_data_heading = %w(UID Sport Name PreferredName Email Phone Units GPA Level Colleges Majors Terms Writing History Institutions Cultures Graduation Alerts)
@@ -27,355 +23,288 @@ describe 'BOAC' do
     @boac_student_page = Page::BOACPages::StudentPage.new @driver
 
     @boac_homepage.dev_auth test.advisor
-    @boac_homepage.click_teams_list
+    @boac_cohort_page.search_and_create_new_cohort test.default_cohort
 
-    expected_team_names = teams.map &:name
-    visible_team_names = @boac_teams_list_page.teams
-    it('shows all the expected teams') { expect(visible_team_names.sort).to eql(expected_team_names.sort) }
+    test.max_cohort_members.sort_by(&:last_name).each do |student|
 
-    if visible_team_names.include? test.default_cohort.name
       begin
+        user_analytics_data = ApiUserAnalyticsPage.new @driver
+        user_analytics_data.get_data(@driver, student)
+        analytics_api_sis_data = user_analytics_data.user_sis_data
 
-        team_members = test.cohort_members.sort_by! &:full_name
-        logger.debug "There are #{team_members.length} total athletes"
-        team_members.keep_if &:active_asc
-        logger.debug "There are #{team_members.length} active athletes"
+        # COHORT PAGE SIS DATA
 
-        @boac_teams_list_page.load_page
-        @boac_teams_list_page.click_team_link test.default_cohort
-        team_url = @boac_cohort_page.current_url
-        @boac_cohort_page.wait_for_team team_members.length
+        @boac_cohort_page.load_cohort test.default_cohort
+        cohort_page_sis_data = @boac_cohort_page.visible_sis_data(@driver, student)
 
-        expected_team_member_names = (team_members.map { |u| "#{u.last_name}, #{u.first_name}" }).sort
-        visible_team_member_names = (@boac_cohort_page.list_view_names).sort
-        it("shows all the expected players for #{test.default_cohort.name}") do
-          logger.debug "Expecting #{expected_team_member_names} and got #{visible_team_member_names}"
-          expect(visible_team_member_names).to eql(expected_team_member_names)
+        it "shows the level for UID #{student.uid} on the #{test.default_cohort.name} page" do
+          expect(cohort_page_sis_data[:level]).to eql(analytics_api_sis_data[:level])
+          expect(cohort_page_sis_data[:level]).not_to be_empty
         end
-        it("shows no blank player names for #{test.default_cohort.name}") { expect(visible_team_member_names.any? &:empty?).to be false }
 
-        expected_team_member_sids = (team_members.map &:sis_id).sort
-        visible_team_member_sids = (@boac_cohort_page.list_view_sids).sort
-        it("shows all the expected player SIDs for #{test.default_cohort.name}") do
-          logger.debug "Expecting #{expected_team_member_sids} and got #{visible_team_member_sids}"
-          expect(visible_team_member_sids).to eql(expected_team_member_sids)
+        it "shows the majors for UID #{student.uid} on the #{test.default_cohort.name} page" do
+          expect(cohort_page_sis_data[:majors]).to eql(analytics_api_sis_data[:majors].sort)
+          expect(cohort_page_sis_data[:majors]).not_to be_empty
         end
-        it("shows no blank player SIDs for #{test.default_cohort.name}") { expect(visible_team_member_sids.any? &:empty?).to be false }
 
-        team_members.each do |team_member|
-          if visible_team_member_sids.include? team_member.sis_id
+        it "shows the cumulative GPA for UID #{student.uid} on the #{test.default_cohort.name} page" do
+          expect(cohort_page_sis_data[:gpa]).to eql(analytics_api_sis_data[:cumulative_gpa])
+          expect(cohort_page_sis_data[:gpa]).not_to be_empty
+        end
+
+        it "shows the units in progress for UID #{student.uid} on the #{test.default_cohort.name} page" do
+          expect(cohort_page_sis_data[:term_units]).to eql(analytics_api_sis_data[:term_units])
+          expect(cohort_page_sis_data[:term_units]).not_to be_empty
+        end
+
+        it "shows the total units for UID #{student.uid} on the #{test.default_cohort.name} page" do
+          expect(cohort_page_sis_data[:units_cumulative]).to eql(analytics_api_sis_data[:cumulative_units])
+          expect(cohort_page_sis_data[:units_cumulative]).not_to be_empty
+        end
+
+        it("shows the current term course codes for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:classes]).to eql(user_analytics_data.current_enrolled_course_codes) }
+
+        # STUDENT PAGE SIS DATA
+
+        @boac_cohort_page.click_student_link student
+        @boac_student_page.wait_for_title student.full_name
+
+        student_page_sis_data = @boac_student_page.visible_sis_data
+
+        it("shows the name for UID #{student.uid} on the student page") { expect(student_page_sis_data[:name]).to eql(student.full_name.split(',').reverse.join(' ').strip) }
+
+        it "shows the email for UID #{student.uid} on the student page" do
+          expect(student_page_sis_data[:email]).to eql(analytics_api_sis_data[:email])
+          expect(student_page_sis_data[:email]).not_to be_empty
+        end
+
+        it "shows the total units for UID #{student.uid} on the student page" do
+          expect(student_page_sis_data[:cumulative_units]).to eql(analytics_api_sis_data[:cumulative_units])
+          expect(student_page_sis_data[:cumulative_units]).not_to be_empty
+        end
+
+        it "shows the phone for UID #{student.uid} on the student page" do
+          expect(student_page_sis_data[:phone]).to eql(analytics_api_sis_data[:phone])
+        end
+
+        it "shows the cumulative GPA for UID #{student.uid} on the student page" do
+          expect(student_page_sis_data[:cumulative_gpa]).to eql(analytics_api_sis_data[:cumulative_gpa])
+          expect(student_page_sis_data[:cumulative_gpa]).not_to be_empty
+        end
+
+        it "shows the majors for UID #{student.uid} on the student page" do
+          expect(student_page_sis_data[:majors]).to eql(analytics_api_sis_data[:majors])
+          expect(student_page_sis_data[:majors]).not_to be_empty
+        end
+
+        analytics_api_sis_data[:colleges] ?
+            (it("shows the colleges for UID #{student.uid} on the student page") { expect(student_page_sis_data[:colleges]).to eql(analytics_api_sis_data[:colleges]) }) :
+            (it("shows no colleges for UID #{student.uid} on the student page") { expect(student_page_sis_data[:colleges]).to be_empty })
+
+        it "shows the academic level for UID #{student.uid} on the student page" do
+          expect(student_page_sis_data[:level]).to eql(analytics_api_sis_data[:level])
+          expect(student_page_sis_data[:level]).not_to be_empty
+        end
+
+        (analytics_api_sis_data[:terms_in_attendance] && analytics_api_sis_data[:level] != 'Graduate') ?
+            (it("shows the terms in attendance for UID #{student.uid} on the student page") { expect(student_page_sis_data[:terms_in_attendance]).to include(analytics_api_sis_data[:terms_in_attendance]) }) :
+            (it("shows no terms in attendance for UID #{student.uid} on the student page") { expect(student_page_sis_data[:terms_in_attendance]).to be_nil })
+
+        analytics_api_sis_data[:level] == 'Graduate' ?
+            (it("shows no expected graduation date for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(student_page_sis_data[:expected_graduation]).to be nil }) :
+            (it("shows the expected graduation date for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(student_page_sis_data[:expected_graduation]).to eql(analytics_api_sis_data[:expected_grad_term_name]) })
+
+        it("shows the Entry Level Writing Requirement for UID #{student.uid} on the student page") { expect(student_page_sis_data[:reqt_writing]).to eql(analytics_api_sis_data[:reqt_writing]) }
+        it("shows the American History Requirement for UID #{student.uid} on the student page") { expect(student_page_sis_data[:reqt_history]).to eql(analytics_api_sis_data[:reqt_history]) }
+        it("shows the American Institutions Requirement for UID #{student.uid} on the student page") { expect(student_page_sis_data[:reqt_institutions]).to eql(analytics_api_sis_data[:reqt_institutions]) }
+        it("shows the American Cultures Requirement for UID #{student.uid} on the student page") { expect(student_page_sis_data[:reqt_cultures]).to eql(analytics_api_sis_data[:reqt_cultures]) }
+
+        # ALERTS
+
+        alerts = BOACUtils.get_students_alerts [student]
+        alert_msgs = (alerts.map &:message).sort
+
+        dismissed = BOACUtils.get_dismissed_alerts(alerts).map &:message
+        non_dismissed = alert_msgs - dismissed
+        logger.info "UID #{student.uid} alert count is #{alert_msgs.length}, with #{dismissed.length} dismissed"
+
+        if non_dismissed.any?
+          non_dismissed_visible = @boac_student_page.non_dismissed_alert_msg_elements.all? &:visible?
+          non_dismissed_present = @boac_student_page.non_dismissed_alert_msgs.sort
+          it("has the non-dismissed alert messages for UID #{student.uid} on the student page") { expect(non_dismissed_present).to eql(non_dismissed) }
+          it("shows the non-dismissed alert messages for UID #{student.uid} on the student page") { expect(non_dismissed_visible).to be true }
+        end
+
+        if dismissed.any?
+          dismissed_visible = @boac_student_page.dismissed_alert_msg_elements.any? &:visible?
+          dismissed_present = @boac_student_page.dismissed_alert_msgs.sort
+          it("has the dismissed alert messages for UID #{student.uid} on the student page") { expect(dismissed_present).to eql(dismissed) }
+          it("hides the dismissed alert messages for UID #{student.uid} on the student page") { expect(dismissed_visible).to be false }
+        end
+
+        # TERMS
+
+        terms = user_analytics_data.terms
+        if terms.any?
+          if terms.length > 1
+            @boac_student_page.click_view_previous_semesters
+          else
+            has_view_more_button = @boac_student_page.view_more_button_element.visible?
+            it("shows no View Previous Semesters button for UID #{student.uid} on the student page") { expect(has_view_more_button).to be false }
+          end
+
+          terms.each do |term|
+
             begin
+              term_name = user_analytics_data.term_name term
+              logger.info "Checking #{term_name}"
 
-              user_analytics_data = ApiUserAnalyticsPage.new @driver
-              user_analytics_data.get_data(@driver, team_member)
-              analytics_api_sis_data = user_analytics_data.user_sis_data
+              # COURSES
 
-              # COHORT PAGE SIS DATA
+              term_section_ccns = []
 
-              @boac_cohort_page.navigate_to team_url
-              cohort_page_sis_data = @boac_cohort_page.visible_sis_data(@driver, team_member)
+              if user_analytics_data.courses(term).any?
+                user_analytics_data.courses(term).each do |course|
 
-              it "shows the level for UID #{team_member.uid} on the #{test.default_cohort.name} page" do
-                expect(cohort_page_sis_data[:level]).to eql(analytics_api_sis_data[:level])
-                expect(cohort_page_sis_data[:level]).not_to be_empty
-              end
-
-              it "shows the majors for UID #{team_member.uid} on the #{test.default_cohort.name} page" do
-                expect(cohort_page_sis_data[:majors]).to eql(analytics_api_sis_data[:majors].sort)
-                expect(cohort_page_sis_data[:majors]).not_to be_empty
-              end
-
-              it "shows the cumulative GPA for UID #{team_member.uid} on the #{test.default_cohort.name} page" do
-                expect(cohort_page_sis_data[:gpa]).to eql(analytics_api_sis_data[:cumulative_gpa])
-                expect(cohort_page_sis_data[:gpa]).not_to be_empty
-              end
-
-              it "shows the units in progress for UID #{team_member.uid} on the #{test.default_cohort.name} page" do
-                expect(cohort_page_sis_data[:term_units]).to eql(analytics_api_sis_data[:term_units])
-                expect(cohort_page_sis_data[:term_units]).not_to be_empty
-              end
-
-              it "shows the total units for UID #{team_member.uid} on the #{test.default_cohort.name} page" do
-                expect(cohort_page_sis_data[:units_cumulative]).to eql(analytics_api_sis_data[:cumulative_units])
-                expect(cohort_page_sis_data[:units_cumulative]).not_to be_empty
-              end
-
-              it("shows the current term course codes for UID #{team_member.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:classes]).to eql(user_analytics_data.current_enrolled_course_codes) }
-
-              # STUDENT PAGE SIS DATA
-
-              @boac_cohort_page.click_student_link team_member
-              @boac_student_page.wait_for_title(team_member.full_name)
-
-              # Pause a moment to let the boxplots do their fancy slidey thing
-              sleep 1
-
-              student_page_sis_data = @boac_student_page.visible_sis_data
-
-              it("shows the name for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:name]).to eql(team_member.full_name.split(',').reverse.join(' ').strip) }
-
-              it "shows the email for UID #{team_member.uid} on the student page" do
-                expect(student_page_sis_data[:email]).to eql(analytics_api_sis_data[:email])
-                expect(student_page_sis_data[:email]).not_to be_empty
-              end
-
-              it "shows the total units for UID #{team_member.uid} on the student page" do
-                expect(student_page_sis_data[:cumulative_units]).to eql(analytics_api_sis_data[:cumulative_units])
-                expect(student_page_sis_data[:cumulative_units]).not_to be_empty
-              end
-
-              it "shows the phone for UID #{team_member.uid} on the student page" do
-                expect(student_page_sis_data[:phone]).to eql(analytics_api_sis_data[:phone])
-              end
-
-              it "shows the cumulative GPA for UID #{team_member.uid} on the student page" do
-                expect(student_page_sis_data[:cumulative_gpa]).to eql(analytics_api_sis_data[:cumulative_gpa])
-                expect(student_page_sis_data[:cumulative_gpa]).not_to be_empty
-              end
-
-              it "shows the majors for UID #{team_member.uid} on the student page" do
-                expect(student_page_sis_data[:majors]).to eql(analytics_api_sis_data[:majors])
-                expect(student_page_sis_data[:majors]).not_to be_empty
-              end
-
-              analytics_api_sis_data[:colleges] ?
-                  (it("shows the colleges for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:colleges]).to eql(analytics_api_sis_data[:colleges]) }) :
-                  (it("shows no colleges for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:colleges]).to be_empty })
-
-              it "shows the academic level for UID #{team_member.uid} on the student page" do
-                expect(student_page_sis_data[:level]).to eql(analytics_api_sis_data[:level])
-                expect(student_page_sis_data[:level]).not_to be_empty
-              end
-
-              (analytics_api_sis_data[:terms_in_attendance] && analytics_api_sis_data[:level] != 'Graduate') ?
-                  (it("shows the terms in attendance for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:terms_in_attendance]).to include(analytics_api_sis_data[:terms_in_attendance]) }) :
-                  (it("shows no terms in attendance for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:terms_in_attendance]).to be_nil })
-
-              analytics_api_sis_data[:level] == 'Graduate' ?
-                  (it("shows no expected graduation date for UID #{team_member.uid} on the #{test.default_cohort.name} page") { expect(student_page_sis_data[:expected_grad_term_name]).to be nil }) :
-                  (it("shows the expected graduation date for UID #{team_member.uid} on the #{test.default_cohort.name} page") { expect(student_page_sis_data[:expected_grad_term_name]).to eql(analytics_api_sis_data[:expected_grad_term_name]) })
-
-              it("shows the Entry Level Writing Requirement for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:reqt_writing]).to eql(analytics_api_sis_data[:reqt_writing]) }
-              it("shows the American History Requirement for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:reqt_history]).to eql(analytics_api_sis_data[:reqt_history]) }
-              it("shows the American Institutions Requirement for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:reqt_institutions]).to eql(analytics_api_sis_data[:reqt_institutions]) }
-              it("shows the American Cultures Requirement for UID #{team_member.uid} on the student page") { expect(student_page_sis_data[:reqt_cultures]).to eql(analytics_api_sis_data[:reqt_cultures]) }
-
-              # ALERTS
-
-              alerts = BOACUtils.get_students_alerts [team_member]
-              alert_msgs = (alerts.map &:message).sort
-
-              dismissed = BOACUtils.get_dismissed_alerts(alerts).map &:message
-              non_dismissed = alert_msgs - dismissed
-              logger.info "UID #{team_member.uid} alert count is #{alert_msgs.length}, with #{dismissed.length} dismissed"
-
-              if non_dismissed.any?
-                non_dismissed_visible = @boac_student_page.non_dismissed_alert_msg_elements.all? &:visible?
-                non_dismissed_present = @boac_student_page.non_dismissed_alert_msgs.sort
-                it("has the non-dismissed alert messages for UID #{team_member.uid} on the student page") { expect(non_dismissed_present).to eql(non_dismissed) }
-                it("shows the non-dismissed alert messages for UID #{team_member.uid} on the student page") { expect(non_dismissed_visible).to be true }
-              end
-
-              if dismissed.any?
-                dismissed_visible = @boac_student_page.dismissed_alert_msg_elements.any? &:visible?
-                dismissed_present = @boac_student_page.dismissed_alert_msgs.sort
-                it("has the dismissed alert messages for UID #{team_member.uid} on the student page") { expect(dismissed_present).to eql(dismissed) }
-                it("hides the dismissed alert messages for UID #{team_member.uid} on the student page") { expect(dismissed_visible).to be false }
-              end
-
-              # TERMS
-
-              terms = user_analytics_data.terms
-              if terms.any?
-                if terms.length > 1
-                  @boac_student_page.click_view_previous_semesters
-                else
-                  has_view_more_button = @boac_student_page.view_more_button_element.visible?
-                  it("shows no View Previous Semesters button for UID #{team_member.uid} on the student page") { expect(has_view_more_button).to be false }
-                end
-
-                terms.each do |term|
                   begin
+                    course_sis_data = user_analytics_data.course_sis_data course
+                    course_code = course_sis_data[:code]
 
-                    term_name = user_analytics_data.term_name term
-                    logger.info "Checking #{term_name}"
+                    logger.info "Checking course #{course_code}"
 
-                    courses = user_analytics_data.courses term
+                    @boac_student_page.expand_course_data(term_name, course_code)
 
-                    # COURSES
+                    visible_course_sis_data = @boac_student_page.visible_course_sis_data(term_name, course_code)
+                    visible_course_title = visible_course_sis_data[:title]
+                    visible_units = visible_course_sis_data[:units_completed]
+                    visible_grading_basis = visible_course_sis_data[:grading_basis]
+                    visible_midpoint = visible_course_sis_data[:mid_point_grade]
+                    visible_grade = visible_course_sis_data[:grade]
 
-                    term_section_ccns = []
-
-                    if courses.any?
-                      courses.each do |course|
-                        begin
-
-                          course_sis_data = user_analytics_data.course_sis_data course
-                          course_code = course_sis_data[:code]
-
-                          logger.info "Checking course #{course_code}"
-
-                          @boac_student_page.expand_course_data(term_name, course_code)
-
-                          visible_course_sis_data = @boac_student_page.visible_course_sis_data(term_name, course_code)
-                          visible_course_title = visible_course_sis_data[:title]
-                          visible_units = visible_course_sis_data[:units_completed]
-                          visible_grading_basis = visible_course_sis_data[:grading_basis]
-                          visible_midpoint = visible_course_sis_data[:mid_point_grade]
-                          visible_grade = visible_course_sis_data[:grade]
-
-                          it "shows the course title for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                            expect(visible_course_title).not_to be_empty
-                            expect(visible_course_title).to eql(course_sis_data[:title])
-                          end
-
-                          if course_sis_data[:units_completed].to_f > 0
-                            it "shows the units for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_units).not_to be_empty
-                              expect(visible_units).to eql(course_sis_data[:units_completed])
-                            end
-                          else
-                            it "shows no units for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_units).to be_empty
-                            end
-                          end
-
-                          if course_sis_data[:grading_basis] == 'NON' || !course_sis_data[:grade].empty?
-                            it "shows no grading basis for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_grading_basis).to be_nil
-                            end
-                          else
-                            it "shows the grading basis for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_grading_basis).not_to be_empty
-                              expect(visible_grading_basis).to eql(course_sis_data[:grading_basis])
-                            end
-                          end
-
-                          if course_sis_data[:grade].empty?
-                            it "shows no grade for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_grade).to be_nil
-                            end
-                          else
-                            it "shows the grade for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_grade).not_to be_empty
-                              expect(visible_grade).to eql(course_sis_data[:grade])
-                            end
-                          end
-
-                          if course_sis_data[:midpoint] && term_name == BOACUtils.term
-                            it "shows the midpoint grade for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_midpoint).not_to be_empty
-                              expect(visible_midpoint).to eql(course_sis_data[:midpoint])
-                            end
-                          else
-                            it "shows no midpoint grade for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                              expect(visible_midpoint).to be_nil
-                            end
-                          end
-
-                          # SECTIONS
-
-                          sections = user_analytics_data.sections course
-                          sections.each do |section|
-                            begin
-
-                              index = sections.index section
-                              section_sis_data = user_analytics_data.section_sis_data section
-                              term_section_ccns << section_sis_data[:ccn]
-                              component = section_sis_data[:component]
-
-                              visible_section_sis_data = @boac_student_page.visible_section_sis_data(term_name, course_code, index)
-                              visible_section = visible_section_sis_data[:section]
-                              visible_wait_list_status = visible_course_sis_data[:wait_list]
-
-                              it "shows the section number for UID #{team_member.uid} term #{term_name} course #{course_code} section #{component}" do
-                                expect(visible_section).not_to be_empty
-                                expect(visible_section).to eql("#{section_sis_data[:component]} #{section_sis_data[:number]}")
-                              end
-
-                              if section_sis_data[:status] == 'W'
-                                it "shows the wait list status for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                                  expect(visible_wait_list_status).to be true
-                                end
-                              else
-                                it "shows no enrollment status for UID #{team_member.uid} term #{term_name} course #{course_code}" do
-                                  expect(visible_wait_list_status).to be false
-                                end
-                              end
-
-                            rescue => e
-                              BOACUtils.log_error_and_screenshot(@driver, e, "#{team_member.uid}-#{term_name}-#{course_code}-#{section_sis_data[:ccn]}")
-                              it("encountered an error for UID #{team_member.uid} term #{term_name} course #{course_code} section #{section_sis_data[:ccn]}") { fail }
-                            ensure
-                              row = [team_member.uid, test.default_cohort.name, term_name, course_code, course_sis_data[:title], section_sis_data[:ccn], "#{section_sis_data[:component]} #{section_sis_data[:number]}",
-                                     section_sis_data[:primary], course_sis_data[:midpoint], course_sis_data[:grade], course_sis_data[:grading_basis], course_sis_data[:units_completed], section_sis_data[:status]]
-                              Utils.add_csv_row(user_course_sis_data, row)
-                            end
-                          end
-
-                        rescue => e
-                          BOACUtils.log_error_and_screenshot(@driver, e, "#{team_member.uid}-#{term_name}-#{course_code}")
-                          it("encountered an error for UID #{team_member.uid} term #{term_name} course #{course_code}") { fail }
-                        end
-                      end
-
-                      it("shows no dupe courses for UID #{team_member.uid} in term #{term_name}") { expect(term_section_ccns).to eql(term_section_ccns.uniq) }
-
-                    else
-                      logger.warn "No course data in #{term_name}"
+                    it "shows the course title for UID #{student.uid} term #{term_name} course #{course_code}" do
+                      expect(visible_course_title).not_to be_empty
+                      expect(visible_course_title).to eql(course_sis_data[:title])
                     end
 
-                    # DROPPED SECTIONS
+                    if course_sis_data[:units_completed].to_f > 0
+                      it "shows the units for UID #{student.uid} term #{term_name} course #{course_code}" do
+                        expect(visible_units).not_to be_empty
+                        expect(visible_units).to eql(course_sis_data[:units_completed])
+                      end
+                    else
+                      it("shows no units for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_units).to be_empty }
+                    end
 
-                    drops = user_analytics_data.dropped_sections term
-                    if drops
-                      drops.each do |drop|
-                        visible_drop = @boac_student_page.visible_dropped_section_data(term_name, drop[:title], drop[:component], drop[:number])
-                        (term_name == BOACUtils.term) ?
-                            (it("shows dropped section #{drop[:title]} #{drop[:component]} #{drop[:number]} for UID #{team_member.uid} in #{term_name}") { expect(visible_drop).to be_truthy }) :
-                            (it("shows no dropped section #{drop[:title]} #{drop[:component]} #{drop[:number]} for UID #{team_member.uid} in past term #{term_name}") { expect(visible_drop).to be_falsey })
+                    if course_sis_data[:grading_basis] == 'NON' || !course_sis_data[:grade].empty?
+                      it("shows no grading basis for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_grading_basis).to be_nil }
+                    else
+                      it "shows the grading basis for UID #{student.uid} term #{term_name} course #{course_code}" do
+                        expect(visible_grading_basis).not_to be_empty
+                        expect(visible_grading_basis).to eql(course_sis_data[:grading_basis])
+                      end
+                    end
 
-                        row = [team_member.uid, test.default_cohort.name, term_name, drop[:title], nil, nil, drop[:number], nil, nil, nil, 'D']
+                    if course_sis_data[:grade].empty?
+                      it("shows no grade for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_grade).to be_nil }
+                    else
+                      it "shows the grade for UID #{student.uid} term #{term_name} course #{course_code}" do
+                        expect(visible_grade).not_to be_empty
+                        expect(visible_grade).to eql(course_sis_data[:grade])
+                      end
+                    end
+
+                    if course_sis_data[:midpoint] && term_name == BOACUtils.term
+                      it "shows the midpoint grade for UID #{student.uid} term #{term_name} course #{course_code}" do
+                        expect(visible_midpoint).not_to be_empty
+                        expect(visible_midpoint).to eql(course_sis_data[:midpoint])
+                      end
+                    else
+                      it("shows no midpoint grade for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_midpoint).to be_nil }
+                    end
+
+                    # SECTIONS
+
+                    user_analytics_data.sections(course).each do |section|
+
+                      begin
+                        index = user_analytics_data.sections(course).index section
+                        section_sis_data = user_analytics_data.section_sis_data section
+                        term_section_ccns << section_sis_data[:ccn]
+                        component = section_sis_data[:component]
+
+                        visible_section_sis_data = @boac_student_page.visible_section_sis_data(term_name, course_code, index)
+                        visible_section = visible_section_sis_data[:section]
+                        visible_wait_list_status = visible_course_sis_data[:wait_list]
+
+                        it "shows the section number for UID #{student.uid} term #{term_name} course #{course_code} section #{component}" do
+                          expect(visible_section).not_to be_empty
+                          expect(visible_section).to eql("#{section_sis_data[:component]} #{section_sis_data[:number]}")
+                        end
+
+                        (section_sis_data[:status] == 'W') ?
+                            (it("shows the wait list status for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_wait_list_status).to be true }) :
+                            (it("shows no enrollment status for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_wait_list_status).to be false })
+
+                      rescue => e
+                        BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_code}-#{section_sis_data[:ccn]}")
+                        it("encountered an error for UID #{student.uid} term #{term_name} course #{course_code} section #{section_sis_data[:ccn]}") { fail }
+                      ensure
+                        row = [student.uid, student.sports, term_name, course_code, course_sis_data[:title], section_sis_data[:ccn], "#{section_sis_data[:component]} #{section_sis_data[:number]}",
+                               section_sis_data[:primary], course_sis_data[:midpoint], course_sis_data[:grade], course_sis_data[:grading_basis], course_sis_data[:units_completed], section_sis_data[:status]]
                         Utils.add_csv_row(user_course_sis_data, row)
                       end
                     end
 
                   rescue => e
-                    BOACUtils.log_error_and_screenshot(@driver, e, "#{team_member.uid}-#{term_name}")
-                    it("encountered an error for UID #{team_member.uid} term #{term_name}") { fail }
+                    BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_code}")
+                    it("encountered an error for UID #{student.uid} term #{term_name} course #{course_code}") { fail }
                   end
                 end
 
+                it("shows no dupe courses for UID #{student.uid} in term #{term_name}") { expect(term_section_ccns).to eql(term_section_ccns.uniq) }
+
               else
-                logger.warn "UID #{team_member.uid} has no term data"
+                logger.warn "No course data in #{term_name}"
+              end
+
+              # DROPPED SECTIONS
+
+              drops = user_analytics_data.dropped_sections term
+              if drops
+                drops.each do |drop|
+                  visible_drop = @boac_student_page.visible_dropped_section_data(term_name, drop[:title], drop[:component], drop[:number])
+                  (term_name == BOACUtils.term) ?
+                      (it("shows dropped section #{drop[:title]} #{drop[:component]} #{drop[:number]} for UID #{student.uid} in #{term_name}") { expect(visible_drop).to be_truthy }) :
+                      (it("shows no dropped section #{drop[:title]} #{drop[:component]} #{drop[:number]} for UID #{student.uid} in past term #{term_name}") { expect(visible_drop).to be_falsey })
+
+                  row = [student.uid, student.sports, term_name, drop[:title], nil, nil, drop[:number], nil, nil, nil, 'D']
+                  Utils.add_csv_row(user_course_sis_data, row)
+                end
               end
 
             rescue => e
-              BOACUtils.log_error_and_screenshot(@driver, e, "#{team_member.uid}")
-              it("encountered an error for UID #{team_member.uid}") { fail }
-            ensure
-              if analytics_api_sis_data
-                row = [team_member.uid, test.default_cohort.name, student_page_sis_data[:name], student_page_sis_data[:preferred_name], student_page_sis_data[:email],
-                       student_page_sis_data[:phone], student_page_sis_data[:cumulative_units], student_page_sis_data[:cumulative_gpa], student_page_sis_data[:level],
-                       student_page_sis_data[:colleges] && student_page_sis_data[:colleges] * '; ', student_page_sis_data[:majors] && student_page_sis_data[:majors] * '; ',
-                       student_page_sis_data[:terms_in_attendance], student_page_sis_data[:reqt_writing], student_page_sis_data[:reqt_history],
-                       student_page_sis_data[:reqt_institutions], student_page_sis_data[:reqt_cultures], student_page_sis_data[:expected_grad_term_name], alert_msgs]
-                Utils.add_csv_row(user_profile_sis_data, row)
-              end
+              BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}")
+              it("encountered an error for UID #{student.uid} term #{term_name}") { fail }
             end
-
-          else
-            logger.warn "Skipping #{test.default_cohort.name} UID #{team_member.uid} because it is not present in the UI"
           end
+
+        else
+          logger.warn "UID #{student.uid} has no term data"
         end
 
       rescue => e
-        BOACUtils.log_error_and_screenshot(@driver, e, test.default_cohort.name)
-        it("encountered an error for #{test.default_cohort.name}") { fail }
+        BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}")
+        it("encountered an error for UID #{student.uid}") { fail }
+      ensure
+        if analytics_api_sis_data
+          row = [student.uid, student.sports, student_page_sis_data[:name], student_page_sis_data[:preferred_name], student_page_sis_data[:email],
+                 student_page_sis_data[:phone], student_page_sis_data[:cumulative_units], student_page_sis_data[:cumulative_gpa], student_page_sis_data[:level],
+                 student_page_sis_data[:colleges] && student_page_sis_data[:colleges] * '; ', student_page_sis_data[:majors] && student_page_sis_data[:majors] * '; ',
+                 student_page_sis_data[:terms_in_attendance], student_page_sis_data[:reqt_writing], student_page_sis_data[:reqt_history],
+                 student_page_sis_data[:reqt_institutions], student_page_sis_data[:reqt_cultures], student_page_sis_data[:expected_grad_term_name], alert_msgs]
+          Utils.add_csv_row(user_profile_sis_data, row)
+        end
       end
-
-    else
-      logger.warn "Skipping #{test.default_cohort.name} because there is no link for it"
     end
 
   rescue => e

--- a/spec/boac/boac_user_role_admin_spec.rb
+++ b/spec/boac/boac_user_role_admin_spec.rb
@@ -51,8 +51,15 @@ describe 'An admin using BOAC' do
 
   context 'performing a user search' do
 
-    it('sees CoE-only students in search results') { expect(@search_page.search coe_only_students.first.sis_id).to eql(1) }
-    it('sees ASC-only students in search results') { expect(@search_page.search asc_only_students.first.sis_id).to eql(1) }
+    it('sees CoE-only students in search results') do
+      @search_page.search coe_only_students.first.sis_id
+      expect(@search_page.student_search_results_count).to eql(1)
+    end
+
+    it('sees ASC-only students in search results') do
+      @search_page.search asc_only_students.first.sis_id
+      expect(@search_page.student_search_results_count).to eql(1)
+    end
   end
 
   context 'performing a filtered cohort search' do

--- a/spec/boac/boac_user_role_asc_spec.rb
+++ b/spec/boac/boac_user_role_asc_spec.rb
@@ -50,6 +50,11 @@ describe 'An ASC advisor' do
 
   after(:all) { Utils.quit_browser @driver }
 
+  it 'sees all the expected teams' do
+    @homepage.click_teams_list
+    expect(@teams_page.teams.sort).to eql(NessieUtils.get_asc_teams.map(&:name).sort)
+  end
+
   context 'performing a filtered cohort search' do
 
     before(:all) do
@@ -88,13 +93,24 @@ describe 'An ASC advisor' do
 
   context 'performing a user search' do
 
-    it('sees no non-ASC students in search results') { expect(@search_page.search coe_only_students.first.sis_id).to be_zero }
-    it('sees no inactive ASC students in search results') { expect(@search_page.search @inactive_student_sids.first).to be_zero }
+    it('sees no non-ASC students in search results') do
+      @search_page.search coe_only_students.first.sis_id
+      expect(@search_page.student_search_results_count).to be_zero
+    end
+
+    it('sees no inactive ASC students in search results') do
+      @search_page.search @inactive_student_sids.first
+      expect(@search_page.student_search_results_count).to be_zero
+    end
+
     it('sees overlapping ASC and CoE active students in search results') do
       student = overlap_students.find &:active_asc
-      student ?
-          (expect(@search_page.search student.sis_id).to eql(1)) :
-          logger.warn('Skipping search for overlapping students since none are active')
+      if student
+        @search_page.search student.sis_id
+        expect(@search_page.student_search_results_count).to eql(1)
+      else
+        logger.warn 'Skipping search for overlapping students since none are active'
+      end
     end
   end
 

--- a/spec/boac/boac_user_role_coe_spec.rb
+++ b/spec/boac/boac_user_role_coe_spec.rb
@@ -62,8 +62,15 @@ describe 'A CoE advisor using BOAC' do
 
   context 'when performing a user search' do
 
-    it('sees no non-CoE students in search results') { expect(@search_page.search asc_only_students.first.sis_id).to be_zero }
-    it('sees overlapping CoE and ASC students in search results') { expect(@search_page.search overlap_students.first.sis_id).to eql(1) }
+    it('sees no non-CoE students in search results') do
+      @search_page.search asc_only_students.first.sis_id
+      expect(@search_page.student_search_results_count).to be_zero
+    end
+
+    it('sees overlapping CoE and ASC students in search results') do
+      @search_page.search overlap_students.first.sis_id
+      expect(@search_page.student_search_results_count).to eql(1)
+    end
   end
 
   context 'performing a filtered cohort search' do

--- a/spec/boac/boac_user_search_spec.rb
+++ b/spec/boac/boac_user_search_spec.rb
@@ -78,7 +78,7 @@ describe 'BOAC' do
 
     it 'limits results to 50' do
       @search_page.search '303'
-      expect(@search_page.results_count @search_page.student_results_count_element).to be > 50
+      expect(@search_page.student_search_results_count).to be > 50
       expect(@search_page.student_row_sids.length).to eql(50)
     end
   end


### PR DESCRIPTION
Removes the ASC-specific logic from the test script for BOAC SIS data (causing lots of changes to indentation). Also fixes a few small test bugs.