### PR TITLE
Test updates and fixes for BOAC v2.10 changes

### DIFF
--- a/models/boac/cohort.rb
+++ b/models/boac/cohort.rb
@@ -1,6 +1,6 @@
 class Cohort
 
-  attr_accessor :id, :name, :owner_uid
+  attr_accessor :id, :name, :owner_uid, :members, :member_data
 
   def initialize(cohort_data)
     cohort_data.each { |k, v| public_send("#{k}=", v) }

--- a/models/boac/cohort_filter.rb
+++ b/models/boac/cohort_filter.rb
@@ -12,8 +12,10 @@ class CohortFilter
                 :gender,
                 :underrepresented_minority,
                 :prep,
-                :inactive,
-                :intensive,
+                :inactive_coe,
+                :probation_coe,
+                :inactive_asc,
+                :intensive_asc,
                 :team
 
   # Sets cohort filters based on test data
@@ -33,10 +35,12 @@ class CohortFilter
     @gender = (test_data['genders'] && test_data['genders'].map { |g| g['gender'] })
     @underrepresented_minority = test_data['minority']
     @prep = (test_data['preps'] && test_data['preps'].map { |p| p['prep'] })
+    @inactive_coe = test_data['inactive_coe']
+    @probation_coe = test_data['probation_coe']
 
     # ASC
-    @inactive = test_data['inactive_asc']
-    @intensive = test_data['intensive_asc']
+    @inactive_asc = test_data['inactive_asc']
+    @intensive_asc = test_data['intensive_asc']
     @team = (test_data['teams'] && test_data['teams'].map { |t| Squad::SQUADS.find { |s| s.name == t['squad'] } })
 
     # Remove filters that are not available to the department
@@ -46,9 +50,11 @@ class CohortFilter
       @gender = nil
       @underrepresented_minority = nil
       @prep = nil
+      @inactive_coe = nil
+      @probation_coe = nil
     elsif dept == BOACDepartments::COE
-      @inactive = nil
-      @intensive = nil
+      @inactive_asc = nil
+      @intensive_asc = nil
       @team = nil
     end
   end

--- a/models/boac/filtered_cohort.rb
+++ b/models/boac/filtered_cohort.rb
@@ -1,6 +1,6 @@
 class FilteredCohort < Cohort
 
-  attr_accessor :search_criteria, :member_count, :member_data
+  attr_accessor :search_criteria, :member_count
 
   def initialize(cohort_data)
     cohort_data.each { |k, v| public_send("#{k}=", v) }

--- a/pages/boac/class_list_view_page.rb
+++ b/pages/boac/class_list_view_page.rb
@@ -15,6 +15,13 @@ module Page
         elements(:student_link, :link, xpath: '//tr[@data-ng-repeat="student in section.students"]//a')
         elements(:student_sid, :div, xpath: '//tr[@data-ng-repeat="student in section.students"]//div[contains(@class, "student-sid")]')
 
+        # Returns the XPath for a student row in the class page table
+        # @param student [BOACUser]
+        # @return [String]
+        def list_view_user_xpath(student)
+          "//tr[@data-ng-repeat=\"student in section.students\"][contains(.,\"#{student.sis_id}\")]"
+        end
+
         # Returns all the SIDs shown on list view
         # @return [Array<String>]
         def list_view_sids
@@ -80,7 +87,7 @@ module Page
         # @param node [Integer]
         # @return [String]
         def assigns_submit_score(student, node)
-          el = div_element(xpath: "(#{list_view_user_xpath student}//div[contains(@class,\"course-list-view-column-04\")]//div[@data-ng-repeat=\"canvasSite in student.enrollment.canvasSites\"])[#{node}]//strong[@data-ng-bind=\"canvasSite.analytics.assignmentsSubmitted.student.raw\"]")
+          el = div_element(xpath: "(#{list_view_user_xpath student}/td[5]//div[@data-ng-repeat=\"canvasSite in student.enrollment.canvasSites\"])[#{node}]//strong[@data-ng-bind=\"canvasSite.analytics.assignmentsSubmitted.student.raw\"]")
           el.text if el.exists?
         end
 
@@ -89,7 +96,7 @@ module Page
         # @param node [Integer]
         # @return [String]
         def assigns_submit_max(student, node)
-          el = span_element(xpath: "(#{list_view_user_xpath student}//div[contains(@class,\"course-list-view-column-04\")]//div[@data-ng-repeat=\"canvasSite in student.enrollment.canvasSites\"])[#{node}]//span[@data-ng-bind=\"canvasSite.analytics.assignmentsSubmitted.courseDeciles[10]\"]")
+          el = span_element(xpath: "(#{list_view_user_xpath student}/td[5]//div[@data-ng-repeat=\"canvasSite in student.enrollment.canvasSites\"])[#{node}]//span[@data-ng-bind=\"canvasSite.analytics.assignmentsSubmitted.courseDeciles[10]\"]")
           el.text if el.exists?
         end
 
@@ -98,7 +105,7 @@ module Page
         # @param node [Integer]
         # @return [String]
         def assigns_submit_no_data(student, node)
-          el = div_element(xpath: "(#{list_view_user_xpath student}//div[contains(@class,\"course-list-view-column-04\")]//div[@data-ng-repeat=\"canvasSite in student.enrollment.canvasSites\"])[#{node}][contains(.,\"No Data\")]")
+          el = div_element(xpath: "(#{list_view_user_xpath student}/td[5]//div[@data-ng-repeat=\"canvasSite in student.enrollment.canvasSites\"])[#{node}][contains(.,\"No Data\")]")
           el.text if el.exists?
         end
 
@@ -107,7 +114,7 @@ module Page
         # @param node [Integer]
         # @return [String]
         def assigns_grade_xpath(student, node)
-          "(#{list_view_user_xpath student}/div[@class=\"course-list-view-column-05 ng-scope\"]//div[@class=\"profile-boxplot-container ng-scope\"])[#{node}]"
+          "(#{list_view_user_xpath student}/td[6]//div[@class=\"profile-boxplot-container ng-scope\"])[#{node}]"
         end
 
         # Returns the student's assignment total score for a site at a given node. If a boxplot exists, mouses over it to reveal the score.
@@ -116,7 +123,7 @@ module Page
         # @param node [Integer]
         # @return [String]
         def assigns_grade_score(driver, student, node)
-          score_xpath = "(#{list_view_user_xpath student}/div[@class=\"course-list-view-column-05 ng-scope\"]//div[@class=\"profile-boxplot-container ng-scope\"])[#{node}]"
+          score_xpath = "(#{list_view_user_xpath student}/td[6]//div[@class=\"profile-boxplot-container ng-scope\"])[#{node}]"
           has_boxplot = verify_block { mouseover(driver, driver.find_element(xpath: "#{score_xpath}//*[@class=\"highcharts-boxplot-box\"]")) }
           el = has_boxplot ?
               div_element(xpath: "#{score_xpath}//div[text()=\"User Score\"]/following-sibling::div") :
@@ -155,7 +162,7 @@ module Page
         # @param node [Integer]
         # @return [String]
         def last_activity(student, node)
-          el = span_element(xpath: "(#{list_view_user_xpath student}/div[@class=\"course-list-view-column-06 ng-scope\"]//div[@class=\"profile-boxplot-container ng-scope\"])[#{node}]/span")
+          el = span_element(xpath: "(#{list_view_user_xpath student}/td[7]//div[@class=\"profile-boxplot-container ng-scope\"])[#{node}]/span")
           el.text if el.exists?
         end
 

--- a/pages/boac/class_matrix_view_page.rb
+++ b/pages/boac/class_matrix_view_page.rb
@@ -23,8 +23,8 @@ module Page
         end
 
         div(:matrix, id: 'scatterplot')
-        elements(:missing_data_link, :link, xpath: '//a[contains(@data-ng-repeat,"student in studentsWithoutData")]')
-        elements(:missing_data_row, :image, xpath: '//table[@class="missing-student-data-table"]//tr[contains(@class,"student-list-item")]')
+        elements(:missing_data_link, :link, xpath: '//table[@class="missing-student-data-table"]//a[contains(@href,"/student/")]')
+        elements(:missing_data_row, :image, xpath: '//table[@class="missing-student-data-table"]//tr[contains(@class,"cohort-missing-student-data-row")]')
 
         # Waits for the matrix graphic to appear and pauses briefly to allow bubbles to start forming
         def wait_for_matrix

--- a/pages/boac/home_page.rb
+++ b/pages/boac/home_page.rb
@@ -61,13 +61,13 @@ module Page
           driver.find_elements(xpath: "#{xpath}//tr[contains(@data-ng-repeat,'student in students')]")
         end
 
-        # FILTERED COHORTS
+        # FILTERED COHORTS AND CURATED GROUPS
 
-        elements(:filtered_cohort, :span, xpath: '//div[@data-ng-repeat="cohort in profile.myFilteredCohorts track by $index"]//h2/span[1]')
-        link(:home_create_filtered_link, id: 'create-another-filtered-cohort')
+        elements(:filtered_cohort, :span, xpath: '//div[@data-ng-repeat="cohort in profile.myFilteredCohorts track by $index"]//h2/span[@data-ng-bind="cohort.name"]')
         h1(:no_filtered_cohorts_msg, xpath: '//h1[contains(.,"You have no saved cohorts.")]')
+        elements(:curated_group, :span, xpath: '//div[@data-ng-repeat="cohort in profile.myCuratedCohorts track by $index"]//h2/span[@data-ng-bind="cohort.name"]')
 
-        # Returns the names of My Saved Cohorts shown on the homepage
+        # Returns the names of filtered cohorts shown on the homepage
         # @return [Array<String>]
         def filtered_cohorts
           h1_element(xpath: '//h1[contains(text(),"Cohorts")]').when_present Utils.medium_wait
@@ -75,50 +75,76 @@ module Page
           filtered_cohort_elements.map &:text
         end
 
-        # Returns the 'view all' link on a filtered cohort row
+        # Returns the XPath to a filtered cohort's div in the main content area on the homepage
         # @param cohort [FilteredCohort]
+        # @return [String]
+        def filtered_cohort_xpath(cohort)
+          "//div[@id=\"content\"]//div[@data-ng-repeat=\"cohort in profile.myFilteredCohorts track by $index\"][contains(.,\"#{cohort.name}\")]"
+        end
+
+        # Returns the names of curated groups shown on the homepage
+        # @return [Array<String>]
+        def curated_groups
+          h1_element(xpath: '//h1[contains(text(),"Curated Groups")]').when_present Utils.medium_wait
+          wait_until(Utils.medium_wait) { curated_group_elements.any? }
+          curated_group_elements.map &:text
+        end
+
+        # Returns the XPath to a curated group's div in the main content area on the homepage
+        # @param group [CuratedGroup]
+        # @return [String]
+        def curated_group_xpath(group)
+          "//div[@id=\"content\"]//div[@data-ng-repeat=\"cohort in profile.myCuratedCohorts track by $index\"][contains(.,\"#{group.name}\")]"
+        end
+
+        # Returns the link to a filtered cohort or curated group in the main content area of the homepage
+        # @param cohort [Cohort]
         # @return [PageObject::Elements::Link]
-        def filtered_cohort_view_all_link(cohort)
-          link_element(xpath: "//h1[contains(text(),'Cohorts')]/../following-sibling::*//a[contains(@href,'/filtered?id=#{cohort.id}')]")
+        def view_all_members_link(cohort)
+          cohort.instance_of?(FilteredCohort) ?
+              link_element(xpath: "#{filtered_cohort_xpath cohort}//a[contains(@href,'/filtered?id=#{cohort.id}')]") :
+              link_element(xpath: "#{curated_group_xpath cohort}//a[contains(@href,'/curated/#{cohort.id}')]")
         end
 
-        # Expands a filtered cohort row in the main content area
-        # @param cohort [FilteredCohort]
-        def expand_filtered_cohort(cohort)
-          wait_for_update_and_click link_element(xpath: "#{filtered_cohort_xpath cohort}//a") unless filtered_cohort_view_all_link(cohort).visible?
+        # Expands a filtered cohort or curated group row in the main content area
+        # @param cohort [Cohort]
+        def expand_member_rows(cohort)
+          unless view_all_members_link(cohort).visible?
+            cohort.instance_of?(FilteredCohort) ?
+                wait_for_update_and_click(link_element(xpath: "#{filtered_cohort_xpath cohort}//a")) :
+                wait_for_update_and_click(link_element(xpath: "#{curated_group_xpath cohort}//a"))
+          end
         end
 
-        # Returns all the user divs beneath a cohort
+        # Returns all the user divs beneath a filtered cohort or curated group
         # @param driver [Selenium::WebDriver]
-        # @param cohort [FilteredCohort]
+        # @param cohort [Cohort]
         # @return [Array<Selenium::WebDriver::Element>]
-        def filtered_cohort_member_rows(driver, cohort)
-          user_rows(driver, filtered_cohort_xpath(cohort))
+        def member_rows(driver, cohort)
+          cohort.instance_of?(FilteredCohort) ?
+            user_rows(driver, filtered_cohort_xpath(cohort)) :
+            user_rows(driver, curated_group_xpath(cohort))
         end
 
-        # Returns the membership count shown for a cohort
-        # @param cohort [FilteredCohort]
+        # Returns the membership count shown for a filtered cohort or curated group
+        # @param cohort [Cohort]
         # @return [Integer]
-        def filtered_cohort_member_count(cohort)
-          el = span_element(xpath: "#{filtered_cohort_xpath cohort}//span[@data-ng-bind=\"cohort.totalStudentCount\"]")
-          el && el.text.to_i
+        def member_count(cohort)
+          xpath = cohort.instance_of?(FilteredCohort) ?
+              "#{filtered_cohort_xpath(cohort)}//span[@data-ng-bind=\"cohort.totalStudentCount\"]" :
+              "#{curated_group_xpath(cohort)}//span[@data-ng-bind=\"cohort.studentCount\"]"
+          el = span_element(xpath: xpath)
+          el.text.to_i if el.exists?
         end
 
-        def visible_filtered_cohort_members(driver, cohort, searchable_students)
-          expand_filtered_cohort cohort
-          visible_sids = all_row_sids(driver, cohort)
-          searchable_students.select { |s| visible_sids.include? s[:sid] }
-        end
-
-        # Verifies the user + alert data shown for a cohort's membership
+        # Verifies the user + alert data shown for a filtered cohort's or curated group's membership
         # @param driver [Selenium::WebDriver]
-        # @param cohort [FilteredCohort]
-        # @param members [Array<User>]
+        # @param cohort [Cohort]
         # @param advisor [User]
-        def verify_filtered_cohort_alerts(driver, cohort, members, advisor)
+        def verify_member_alerts(driver, cohort, advisor)
 
           # Only cohort members with alerts should be shown. Collect the expected alert count for each member, and toss out those with a zero count.
-          member_alerts = members.any? ? BOACUtils.get_un_dismissed_users_alerts(members, advisor) : []
+          member_alerts = cohort.members.any? ? BOACUtils.get_un_dismissed_users_alerts(cohort.members, advisor) : []
           cohort.member_data.keep_if do |member|
             alert_count = member_alerts.count { |a| a.user.sis_id == member[:sid] }
             logger.debug "SID #{member[:sid]} has alert count #{alert_count}" unless alert_count.zero?
@@ -127,15 +153,17 @@ module Page
           end
 
           # Expand the cohort, and verify that there are only rows for members with alerts
-          wait_until(1, "Expecting cohort #{cohort.name} to have row count of #{cohort.member_data.length}, got #{filtered_cohort_member_rows(driver, cohort).length}") do
-            filtered_cohort_member_rows(driver, cohort).length == cohort.member_data.length
+          view_all_members_link(cohort).when_visible Utils.short_wait
+          wait_until(1, "Expecting cohort #{cohort.name} to have row count of #{cohort.member_data.length}, got #{member_rows(driver, cohort).length}") do
+            member_rows(driver, cohort).length == cohort.member_data.length
           end
 
           # Verify that there is a row for each student with a positive alert count and that the alert count is right
+          xpath = cohort.instance_of?(FilteredCohort) ? filtered_cohort_xpath(cohort) : curated_group_xpath(cohort)
           cohort.member_data.each do |member|
             logger.debug "Checking cohort row for SID #{member[:sid]}"
-            wait_until(1, "Expecting alert count #{member[:alert_count]}, got #{user_row_data(driver, member[:sid], cohort)[:alert_count]}") do
-              user_row_data(driver, member[:sid], cohort)[:alert_count] == member[:alert_count].to_s
+            wait_until(1, "Expecting SID #{member[:sid]} alert count #{member[:alert_count]}, got #{user_row_data(driver, member[:sid], xpath)[:alert_count]}") do
+              user_row_data(driver, member[:sid], xpath)[:alert_count] == member[:alert_count].to_s
             end
           end
         end
@@ -145,7 +173,7 @@ module Page
         def click_filtered_cohort(cohort)
           logger.debug "Clicking link to my cohort '#{cohort.name}'"
           wait_until(Utils.short_wait) { filtered_cohort_elements.any? }
-          wait_for_update_and_click_js filtered_cohort_view_all_link(cohort)
+          wait_for_update_and_click_js view_all_members_link(cohort)
         end
 
       end

--- a/pages/boac/search_results_page.rb
+++ b/pages/boac/search_results_page.rb
@@ -32,8 +32,8 @@ module Page
         # STUDENT SEARCH
 
         span(:student_results_count, xpath: '//span[@count="search.totalStudentCount"]')
-        elements(:student_row, :div, xpath: '//div[contains(@data-ng-repeat,"student in students")]')
-        elements(:student_row_sid, :div, xpath: '//div[contains(@data-ng-repeat,"student in students")]//span[@data-ng-bind="student.sid"]')
+        elements(:student_row, :row, xpath: '//tr[contains(@data-ng-repeat,"student in students")]')
+        elements(:student_row_sid, :span, xpath: '//tr[contains(@data-ng-repeat,"student in students")]//span[@data-ng-bind="student.sid"]')
 
         # Returns the result count for a student search
         # @return [Integer]
@@ -74,7 +74,7 @@ module Page
         # Clicks the search results row for a given student
         # @param student [User]
         def click_student_result(student)
-          wait_for_update_and_click div_element(xpath: "//div[contains(@class,'group-summary-row')][contains(.,'#{student.sis_id}')]//a")
+          wait_for_update_and_click row_element(xpath: "//tr[contains(@data-ng-repeat,'student in students')][contains(.,'#{student.sis_id}')]//a")
           wait_for_spinner
         end
 
@@ -147,11 +147,12 @@ module Page
 
         # Adds all the students on a page to a curated group
         # @param group [CuratedGroup]
-        def selector_add_all_students_to_curated(group)
+        def selector_add_all_students_to_curated(all_students, group)
           wait_until(Utils.short_wait) { add_individual_to_curated_checkbox_elements.any? &:visible? }
           wait_for_update_and_click add_all_to_curated_checkbox_element
           logger.debug "There are #{add_individual_to_curated_checkbox_elements.length} individual checkboxes"
-          students = add_individual_to_curated_checkbox_elements.map { |el| User.new({uid: el.attribute('id').split('-')[1]}) }
+          visible_uids = add_individual_to_curated_checkbox_elements.map { |el| el.attribute('id').split('-')[0] }
+          students = all_students.select { |student| visible_uids.include? student.uid }
           select_group_and_add(students, group)
         end
 

--- a/pages/boac/student_page.rb
+++ b/pages/boac/student_page.rb
@@ -13,16 +13,16 @@ module Page
 
       h1(:not_found_msg, xpath: '//h1[text()="Not Found"]')
 
-      h2(:preferred_name, :class => 'student-preferred-name')
+      div(:preferred_name, :class => 'student-preferred-name')
       span(:sid, xpath: '//span[@data-ng-bind="student.sid"]')
       span(:phone, xpath: '//span[@data-ng-bind="student.sisProfile.phoneNumber"]')
       link(:email, xpath: '//a[@data-ng-bind="student.sisProfile.emailAddress"]')
-      div(:cumulative_units, xpath: '//div[@data-ng-bind="student.sisProfile.cumulativeUnits"]')
+      div(:cumulative_units, xpath: '//div[@data-ng-bind="cumulativeUnits"]')
       div(:cumulative_gpa, xpath: '//div[contains(@data-ng-bind,"student.sisProfile.cumulativeGPA")]')
-      h4(:inactive_flag, xpath: '//h4[text()="INACTIVE"]')
-      elements(:major, :h4, xpath: '//div[@data-ng-repeat="plan in student.sisProfile.plans"]/h4')
+      div(:inactive_flag, xpath: '//div[text()="INACTIVE"]')
+      elements(:major, :div, xpath: '//*[@data-ng-bind="plan.description"]')
       elements(:college, :div, xpath: '//div[@data-ng-bind="plan.program"]')
-      h4(:level, xpath: '//h4[@data-ng-bind="student.sisProfile.level.description"]')
+      div(:level, xpath: '//div[@data-ng-bind="student.sisProfile.level.description"]')
       span(:terms_in_attendance, xpath: '//div[@data-ng-if="student.sisProfile.termsInAttendance"]')
       span(:expected_graduation, xpath: '//span[@data-ng-bind="student.sisProfile.expectedGraduationTerm.name"]')
 
@@ -218,7 +218,7 @@ module Page
       # @return [Hash]
       def visible_course_sis_data(term_name, course_code)
         course_xpath = course_data_xpath(term_name, course_code)
-        title_xpath = "#{course_xpath}//h5"
+        title_xpath = "#{course_xpath}//div[@data-ng-bind='course.title']"
         units_xpath = "#{course_xpath}//span[@count='course.units']"
         grading_basis_xpath = "#{course_xpath}//span[contains(@class, 'profile-class-grading-basis')]"
         mid_point_grade_xpath = "#{course_xpath}//span[contains(@data-ng-bind,'course.midtermGrade')]"
@@ -295,7 +295,7 @@ module Page
       # @param label [String]
       # @return [String]
       def site_analytics_percentile_xpath(site_xpath, label)
-        "#{site_xpath}//td[text()='#{label}']/following-sibling::td[1]"
+        "#{site_xpath}//th[contains(text(),'#{label}')]/following-sibling::td[1]"
       end
 
       # Returns the XPath to the detailed score and percentile analytics data for a given category, for example 'page views'
@@ -303,7 +303,7 @@ module Page
       # @param label [String]
       # @return [String]
       def site_analytics_score_xpath(site_xpath, label)
-        "#{site_xpath}//td[text()='#{label}']/following-sibling::td[2]"
+        "#{site_xpath}//th[contains(text(),'#{label}')]/following-sibling::td[2]"
       end
 
       # Returns the XPath to the boxplot graph for a particular set of analytics data for a given site, for example 'page views'
@@ -336,6 +336,7 @@ module Page
       # @param label [String]
       # @return [String]
       def perc_round(site_xpath, label)
+        logger.debug "Hitting XPath: #{site_analytics_percentile_xpath(site_xpath, label)}"
         cell_element(:xpath => "#{site_analytics_percentile_xpath(site_xpath, label)}/strong").text
       end
 
@@ -399,7 +400,7 @@ module Page
       # @param api_analytics [Hash]
       # @return [Hash]
       def visible_assignment_analytics(driver, site_xpath, api_analytics)
-        visible_analytics(driver, site_xpath, 'Assignments on Time', api_analytics)
+        visible_analytics(driver, site_xpath, 'Assignments Submitted', api_analytics)
       end
 
       # Returns the assignments-grades analytics data shown for a given site
@@ -419,12 +420,12 @@ module Page
       def visible_days_since(term_name, course_code, index)
         # Look first for days since last activity
         begin
-          xpath = "#{course_site_xpath(term_name, course_code, index)}//td[contains(.,\"Last bCourses Activity\")]/following-sibling::td//span[2]"
+          xpath = "#{course_site_xpath(term_name, course_code, index)}//th[contains(.,\"Last bCourses Activity\")]/following-sibling::td//span[2]"
           span_element(:xpath => xpath).when_visible(Utils.click_wait)
           span_element(:xpath => xpath).text
         # If no days-since exists, check for 'never'
         rescue
-          el = div_element(:xpath => "#{course_site_xpath(term_name, course_code, index)}//td[contains(.,\"Last bCourses Activity\")]/following-sibling::td/div")
+          el = div_element(:xpath => "#{course_site_xpath(term_name, course_code, index)}//th[contains(.,\"Last bCourses Activity\")]/following-sibling::td/div")
           el.text if el.exists?
         end
       end

--- a/pages/boac/user_list_pages.rb
+++ b/pages/boac/user_list_pages.rb
@@ -26,18 +26,17 @@ module Page
         "//div[@id=\"content\"]//div[@data-ng-repeat=\"cohort in profile.myFilteredCohorts track by $index\"][contains(.,\"#{cohort.name}\")]"
       end
 
-      # Returns the data visible for a user on the search results page or in a filtered or curated cohort on the homepage. If a cohort,
-      # then an XPath is required in order to find the user under the right cohort heading.
+      # Returns the data visible for a user on the search results page or in a filtered or curated cohort on the homepage. If an XPath is included,
+      # then returns rows under the associated filtered cohort or curated group.
       # @param driver [Selenium::WebDriver]
       # @param sid [String]
-      # @param cohort [Cohort]
+      # @param cohort_xpath [String]
       # @return [Hash]
-      def user_row_data(driver, sid, cohort = nil)
-        cohort_xpath = filtered_cohort_xpath cohort if cohort && cohort.instance_of?(FilteredCohort)
+      def user_row_data(driver, sid, cohort_xpath = nil)
         row_xpath = "#{cohort_xpath}//tr[contains(@data-ng-repeat,\"student in students\")][contains(.,\"#{sid}\")]"
         name_el = link_element(xpath: "#{row_xpath}//a[@data-ng-bind=\"student.sortableName\"]")
         sid_el = span_element(xpath: "#{row_xpath}//span[@data-ng-bind='student.sid']")
-        major_els = driver.find_elements(xpath: "#{row_xpath}//span[@data-ng-repeat='major in student.majors']")
+        major_els = driver.find_elements(xpath: "#{row_xpath}//div[@data-ng-repeat='major in student.majors']")
         term_units_el = div_element(xpath: "#{row_xpath}//div[contains(@data-ng-bind,'student.term.enrolledUnits')]")
         cumul_units_el = div_element(xpath: "#{row_xpath}//div[contains(@data-ng-bind,'student.cumulativeUnits')]")
         no_cumul_units_el = div_element(xpath: "#{row_xpath}//div[contains(@data-ng-if,'!student.cumulativeUnits')]")
@@ -63,7 +62,7 @@ module Page
       def sort_by_option(option, cohort = nil)
         logger.info "Sorting by #{option}"
         xpath = filtered_cohort_xpath cohort if cohort && cohort.instance_of?(FilteredCohort)
-        wait_for_update_and_click element(xpath: "#{xpath}//th[contains(@class, \"group-summary-column\")][contains(.,\"#{option}\")]")
+        wait_for_update_and_click row_element(xpath: "#{xpath}//th[contains(@class, \"group-summary-column\")][contains(.,\"#{option}\")]")
       end
 
       # LAST NAME

--- a/pages/junction/splash_page.rb
+++ b/pages/junction/splash_page.rb
@@ -29,7 +29,9 @@ module Page
           wait_for_update_and_click toggle_footer_link_element
         rescue
           logger.warn 'Session conflict, CAS page loaded'
-          cal_net.log_in(Utils.super_admin_username, Utils.super_admin_password)
+          cal_net.log_out
+          navigate_to "#{JunctionUtils.junction_base_url}/logout"
+          wait_until(Utils.short_wait) { text.include? 'redirectUrl' }
           load_page
           scroll_to_bottom
           wait_for_update_and_click toggle_footer_link_element

--- a/settings.yml
+++ b/settings.yml
@@ -55,8 +55,7 @@ boac:
   class_page_team: GOW
   class_page_max_users: 5
 
-  curated_cohort_team: BAM
-  curated_cohort_max_users: 51
+  curated_group_team: BAM
 
   last_activity_team: TNM
   last_activity_max_users: 3

--- a/spec/boac/boac_class_pages_spec.rb
+++ b/spec/boac/boac_class_pages_spec.rb
@@ -25,7 +25,7 @@ describe 'BOAC' do
     @search_page = Page::BOACPages::UserListPages::SearchResultsPage.new @driver
 
     @homepage.dev_auth test.advisor
-    @filtered_cohort_page.search_and_create_new_cohort(test.default_cohort) unless test.default_cohort.id
+    @filtered_cohort_page.search_and_create_new_cohort(test.default_cohort, test) unless test.default_cohort.id
 
     test.max_cohort_members.each do |student|
       begin

--- a/spec/boac/boac_navigation_spec.rb
+++ b/spec/boac/boac_navigation_spec.rb
@@ -96,13 +96,6 @@ describe 'BOAC' do
                           student_to_matrix = @class_matrix_page.verify_block { @class_matrix_page.wait_for_matrix }
                           it("returns to the matrix view of #{class_test_case}") { expect(student_to_matrix).to be_truthy }
 
-                          # Hit 'Back' twice
-                          @driver.navigate.back
-                          @driver.navigate.back
-
-                          back_to_student = @student_page.verify_block { @student_page.wait_until(Utils.short_wait) { @student_page.sid == student.sis_id } }
-                          it("returns to the original student UID #{student.uid}") { expect(back_to_student).to be true }
-
                         end
                       end
                     rescue => e

--- a/spec/boac/boac_team_sis_data_spec.rb
+++ b/spec/boac/boac_team_sis_data_spec.rb
@@ -23,7 +23,7 @@ describe 'BOAC' do
     @boac_student_page = Page::BOACPages::StudentPage.new @driver
 
     @boac_homepage.dev_auth test.advisor
-    @boac_cohort_page.search_and_create_new_cohort test.default_cohort
+    @boac_cohort_page.search_and_create_new_cohort(test.default_cohort, test)
 
     test.max_cohort_members.sort_by(&:last_name).each do |student|
 

--- a/spec/boac/boac_user_role_admin_spec.rb
+++ b/spec/boac/boac_user_role_admin_spec.rb
@@ -77,8 +77,10 @@ describe 'An admin using BOAC' do
     it('sees a Ethnicity filter') { expect(@filtered_cohort_page.new_filter_option('Ethnicity').visible?).to be true }
     it('sees a Gender filter') { expect(@filtered_cohort_page.new_filter_option('Gender').visible?).to be true }
     it('sees a PREP filter') { expect(@filtered_cohort_page.new_filter_option('PREP').visible?).to be true }
-    it('sees a Inactive filter') { expect(@filtered_cohort_page.new_filter_option('Inactive').visible?).to be true }
-    it('sees a Intensive filter') { expect(@filtered_cohort_page.new_filter_option('Intensive').visible?).to be true }
+    it('sees an Inactive COE filter') { expect(@filtered_cohort_page.new_filter_option('Inactive (COE)').visible?).to be true }
+    it('sees a Probation filter') { expect(@filtered_cohort_page.new_filter_option('Probation').visible?).to be true }
+    it('sees an Inactive ASC filter') { expect(@filtered_cohort_page.new_filter_option('Inactive (ASC)').visible?).to be true }
+    it('sees an Intensive filter') { expect(@filtered_cohort_page.new_filter_option('Intensive').visible?).to be true }
     it('sees a Team filter') { expect(@filtered_cohort_page.new_filter_option('Team').visible?).to be true }
   end
 

--- a/spec/boac/boac_user_role_coe_spec.rb
+++ b/spec/boac/boac_user_role_coe_spec.rb
@@ -88,14 +88,16 @@ describe 'A CoE advisor using BOAC' do
     it('sees a Ethnicity filter') { expect(@filtered_cohort_page.new_filter_option('Ethnicity').visible?).to be true }
     it('sees a Gender filter') { expect(@filtered_cohort_page.new_filter_option('Gender').visible?).to be true }
     it('sees a PREP filter') { expect(@filtered_cohort_page.new_filter_option('PREP').visible?).to be true }
-    it('sees a Inactive filter') { expect(@filtered_cohort_page.new_filter_option('Inactive').exists?).to be false }
-    it('sees a Intensive filter') { expect(@filtered_cohort_page.new_filter_option('Intensive').exists?).to be false }
-    it('sees a Team filter') { expect(@filtered_cohort_page.new_filter_option('Team').exists?).to be false }
+    it('sees an Inactive COE filter') { expect(@filtered_cohort_page.new_filter_option('Inactive').exists?).to be true }
+    it('sees a Probation filter') { expect(@filtered_cohort_page.new_filter_option('Probation').exists?).to be true }
+    it('sees no Inactive ASC filter') { expect(@filtered_cohort_page.new_filter_option('Inactive (ASC)').exists?).to be false }
+    it('sees no Intensive filter') { expect(@filtered_cohort_page.new_filter_option('Intensive').exists?).to be false }
+    it('sees no Team filter') { expect(@filtered_cohort_page.new_filter_option('Team').exists?).to be false }
 
     it 'cannot hit team filters directly' do
-      @filtered_cohort_page.load_squad Squad::MFB_ST
-      @filtered_cohort_page.wait_for_search_results
-      expect(@filtered_cohort_page.results_count).to be_zero
+      @filtered_cohort_page.navigate_to @filtered_cohort_page.squad_url(Squad::MFB_ST)
+      @filtered_cohort_page.new_filter_button_element.when_visible Utils.short_wait
+      expect(@filtered_cohort_page.player_link_elements.any?).to be false
     end
   end
 

--- a/util/boac_utils.rb
+++ b/util/boac_utils.rb
@@ -32,11 +32,6 @@ class BOACUtils < Utils
     @config['assignments_term']
   end
 
-  # Returns the UID of a CoE advisor for testing
-  def self.test_coe_advisor_uid
-    @config['test_coe_advisor_uid']
-  end
-
   # Whether or not to check tooltips during tests. Checking tooltips slows down test execution.
   def self.tooltips
     @config['tooltips']
@@ -50,15 +45,6 @@ class BOACUtils < Utils
   # Whether or not to check Nessie assignments submission counts during tests.
   def self.nessie_assignments
     @config['nessie_assignments']
-  end
-
-  # The advisor department to use for tests that can run with different departments
-  def self.test_dept
-    BOACDepartments::DEPARTMENTS.find { |d| d.code == @config['test_dept'] }
-  end
-
-  def self.sis_data_team
-    @config['sis_data_team']
   end
 
   # Whether or not to compare student data to fellow cohort members in Canvas prod

--- a/util/utils.rb
+++ b/util/utils.rb
@@ -41,11 +41,11 @@ class Utils
   # @return [Selenium::WebDriver]
   def self.launch_browser(profile = nil)
     driver_config = @config['webdriver']
-    driver = driver_config['browser']
-    logger.info "Launching #{driver.capitalize}#{(' using profile at ' + profile) if profile}"
+    browser = driver_config['browser']
+    logger.info "Launching #{browser.capitalize}#{(' using profile at ' + profile) if profile}"
 
     # When launching browser, select the profile to use, tweak profile settings to facilitate file downloads, and launch in headless mode if desired.
-    case driver
+    driver = case browser
 
       when 'chrome'
         options = Selenium::WebDriver::Chrome::Options.new
@@ -80,6 +80,8 @@ class Utils
         logger.error 'Designated WebDriver is not supported'
         nil
     end
+    driver.manage.window.resize_to(1600,900)
+    driver
   end
 
   def self.optional_chrome_profile_dir


### PR DESCRIPTION
Includes
- Handles UI and logic changes for curated groups
- Adds tests for groups on homepage
- Adds tests for new CoE cohort filters
- Fixes tests broken by accessibility fixes

Bonus
- Adds a workaround in Junction tests for the auth-test bug
- Enlarges browser window size to avoid not-clickable errors in headless mode