### PR TITLE
Avoid test failures caused by previous test runs

### DIFF
--- a/spec/junction/canvas_lti_course_add_user_spec.rb
+++ b/spec/junction/canvas_lti_course_add_user_spec.rb
@@ -33,7 +33,7 @@ describe 'bCourses Find a Person to Add', order: :defined do
     @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
     @canvas.masquerade_as(@driver, teacher_1)
 
-    @create_course_site_page.provision_course_site(@driver, course, teacher_1, sections_for_site) if course.site_id.nil?
+    @create_course_site_page.provision_course_site(@driver, course, teacher_1, sections_for_site)
     @canvas.publish_course_site(@driver, course)
   end
 

--- a/spec/junction/canvas_lti_rosters_spec.rb
+++ b/spec/junction/canvas_lti_rosters_spec.rb
@@ -37,8 +37,8 @@ describe 'bCourses Roster Photos' do
     @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
     @canvas.masquerade_as(@driver, teacher_1)
 
-    # Create test course site if necessary
-    @create_course_site_page.provision_course_site(@driver, course, teacher_1, sections_for_site) unless course.site_id
+    # Create test course site
+    @create_course_site_page.provision_course_site(@driver, course, teacher_1, sections_for_site)
     @canvas.publish_course_site(@driver, course)
 
     # Get enrollment totals on site

--- a/spec/junction/junction_background_tasks_spec.rb
+++ b/spec/junction/junction_background_tasks_spec.rb
@@ -18,7 +18,7 @@ describe 'Junction background tasks' do
     @canvas_page = Page::CanvasPage.new @driver
 
     # Log in to both Canvas and Junction
-    @canvas_page.log_in(@cal_net_page, Utils.ets_qa_username, Utils.ets_qa_password)
+    @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password)
     @splash_page.basic_auth config.admin.uid
 
     tests = test_data.map do |data|


### PR DESCRIPTION
Always start with a fresh course site, since recycled sites can contain data that will cause false failures.  Also, use the same admin account for all tests.