### PR TITLE
BOAC-1649, correct /cohort URL; use new ids on BOAC

### DIFF
--- a/pages/boac/boac_cohort_pages.rb
+++ b/pages/boac/boac_cohort_pages.rb
@@ -102,7 +102,7 @@ module BOACCohortPages
 
   # SORTING
 
-  select_list(:cohort_sort_select, id: 'cohort-sort-by')
+  select_list(:cohort_sort_select, id: 'sort-students-by')
 
   # Sorts cohort search results by a given option
   # @param option [String]

--- a/pages/boac/boac_filtered_cohort_page.rb
+++ b/pages/boac/boac_filtered_cohort_page.rb
@@ -72,7 +72,7 @@ class BOACFilteredCohortPage
 
   # FILTERED COHORTS - Creation
 
-  button(:save_cohort_button_one, id: 'save-cohort')
+  button(:save_cohort_button_one, id: 'save-button')
   text_area(:cohort_name_input, id: 'create-input')
   span(:title_required_msg, xpath: '//span[text()="Required"]')
   button(:save_cohort_button_two, id: 'create-confirm')
@@ -145,7 +145,7 @@ class BOACFilteredCohortPage
     click_view_everyone_cohorts
     wait_for_spinner
     wait_until(Utils.short_wait) { everyone_cohort_link_elements.any? }
-    cohorts = everyone_cohort_link_elements.map { |link| FilteredCohort.new({id: link.attribute('href').gsub("#{BOACUtils.base_url}/cohort/filtered?id=", ''), name: link.text}) }
+    cohorts = everyone_cohort_link_elements.map { |link| FilteredCohort.new({id: link.attribute('href').gsub("#{BOACUtils.base_url}/cohort/", ''), name: link.text}) }
     cohorts = cohorts.flatten
     logger.info "Visible Everyone's Cohorts are #{cohorts.map &:name}"
     cohorts
@@ -174,7 +174,7 @@ class BOACFilteredCohortPage
   button(:unsaved_filter_add_button, id: 'unsaved-filter-add')
   button(:unsaved_filter_cancel_button, id: 'unsaved-filter-reset')
   button(:unsaved_filter_apply_button, id: 'unsaved-filter-apply')
-  button(:save_cohort_button, id: 'unsaved-filter-save-cohort')
+  button(:save_cohort_button, id: 'save-button')
 
   elements(:filter_row_type, :span, xpath: '//div[@class="cohort-filter-item-filter"]/span')
   elements(:filter_row_option, :span, xpath: '//div[@class="cohort-filter-item-name"]/span')
@@ -190,8 +190,8 @@ class BOACFilteredCohortPage
   # Returns a filter sub-option link with given text
   # @param option_name [String]
   # @return [PageObject::Elements::Link]
-  def new_filter_sub_option(option_name)
-    link_element(id: "cohort-filter-subcategory-#{option_name}")
+  def new_filter_sub_option(filter_name, option_name)
+    link_element(id: "#{filter_name}-#{option_name}")
   end
 
   # Returns a filter option list item with given text, used to find 'Advisor' options
@@ -212,7 +212,7 @@ class BOACFilteredCohortPage
     # All others require a selection
     else
       wait_for_update_and_click new_filter_sub_button_element
-      option_element = (filter_name == 'Advisor') ? new_filter_advisor_option(filter_option) : new_filter_sub_option(filter_option)
+      option_element = (filter_name == 'Advisor') ? new_filter_advisor_option(filter_option) : new_filter_sub_option(filter_name, filter_option)
       wait_for_update_and_click option_element
     end
   end

--- a/pages/boac/boac_home_page.rb
+++ b/pages/boac/boac_home_page.rb
@@ -60,7 +60,7 @@ class BOACHomePage
   # FILTERED COHORTS AND CURATED GROUPS
 
   elements(:filtered_cohort, :span, xpath: '//div[@data-ng-repeat="cohort in profile.myFilteredCohorts track by $index"]//h2/span[@data-ng-bind="cohort.name"]')
-  h1(:no_filtered_cohorts_msg, xpath: '//h1[contains(.,"You have no saved cohorts.")]')
+  h1(:no_filtered_cohorts_msg, id: 'no-cohorts-header')
   elements(:curated_group, :span, xpath: '//div[@data-ng-repeat="cohort in profile.myCuratedCohorts track by $index"]//h2/span[@data-ng-bind="cohort.name"]')
 
   # Returns the names of filtered cohorts shown on the homepage
@@ -75,7 +75,7 @@ class BOACHomePage
   # @param cohort [FilteredCohort]
   # @return [String]
   def filtered_cohort_xpath(cohort)
-    "//div[@id=\"content\"]//div[@data-ng-repeat=\"cohort in profile.myFilteredCohorts track by $index\"][contains(.,\"#{cohort.name}\")]"
+    "//div[@id=\"home-cohort-#{cohort.id}\"]"
   end
 
   # Returns the names of curated groups shown on the homepage
@@ -127,7 +127,7 @@ class BOACHomePage
   # @return [Integer]
   def member_count(cohort)
     xpath = cohort.instance_of?(FilteredCohort) ?
-        "#{filtered_cohort_xpath(cohort)}//span[@data-ng-bind=\"cohort.totalStudentCount\"]" :
+        "#{filtered_cohort_xpath(cohort)}//span[@id=\"home-cohort-#{cohort.id}-total-student-count\"]" :
         "#{curated_group_xpath(cohort)}//span[@data-ng-bind=\"cohort.studentCount\"]"
     el = span_element(xpath: xpath)
     el.text.to_i if el.exists?

--- a/pages/boac/boac_pages.rb
+++ b/pages/boac/boac_pages.rb
@@ -100,8 +100,8 @@ module BOACPages
 
   ### SIDEBAR - FILTERED COHORTS ###
 
-  link(:create_filtered_cohort_link, id: 'sidebar-filtered-cohort-create')
-  link(:view_everyone_cohorts_link, id: 'sidebar-filtered-cohorts-all')
+  link(:create_filtered_cohort_link, id: 'cohort-create')
+  link(:view_everyone_cohorts_link, id: 'cohorts-all')
   link(:team_list_link, id: 'sidebar-teams-link')
   link(:intensive_cohort_link, text: 'Intensive Students')
   link(:inactive_cohort_link, text: 'Inactive Students')

--- a/pages/boac/boac_user_list_pages.rb
+++ b/pages/boac/boac_user_list_pages.rb
@@ -20,7 +20,7 @@ module BOACUserListPages
   # @param cohort [FilteredCohort]
   # @return [String]
   def filtered_cohort_xpath(cohort)
-    "//div[@id=\"content\"]//div[@data-ng-repeat=\"cohort in profile.myFilteredCohorts track by $index\"][contains(.,\"#{cohort.name}\")]"
+    "//div[@id=\"home-cohort-#{cohort.id}\"]"
   end
 
   # Returns the data visible for a user on the search results page or in a filtered or curated cohort on the homepage. If an XPath is included,

--- a/spec/boac/boac_filtered_cohort_spec.rb
+++ b/spec/boac/boac_filtered_cohort_spec.rb
@@ -563,7 +563,7 @@ describe 'BOAC', order: :defined do
     end
 
     it 'shows a Not Found page' do
-      @cohort_page.navigate_to "#{BOACUtils.base_url}/cohort/filtered?id=#{test.searches.first.id}"
+      @cohort_page.navigate_to "#{BOACUtils.base_url}/cohort/#{test.searches.first.id}"
       @cohort_page.wait_for_title '404'
     end
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1649

Teena now finds menu options in new `/cohort` design.