### PR TITLE
Handle physics cohorts

### DIFF
--- a/models/boac/cohort_filter.rb
+++ b/models/boac/cohort_filter.rb
@@ -44,7 +44,7 @@ class CohortFilter
     @team = (test_data['teams'] && test_data['teams'].map { |t| Squad::SQUADS.find { |s| s.name == t['squad'] } })
 
     # Remove filters that are not available to the department
-    if dept == BOACDepartments::ASC
+    if [BOACDepartments::ASC, BOACDepartments::PHYSICS].include? dept
       @advisor = nil
       @ethnicity = nil
       @gender = nil
@@ -52,7 +52,7 @@ class CohortFilter
       @prep = nil
       @inactive_coe = nil
       @probation_coe = nil
-    elsif dept == BOACDepartments::COE
+    elsif [BOACDepartments::COE, BOACDepartments::PHYSICS].include? dept
       @inactive_asc = nil
       @intensive_asc = nil
       @team = nil

--- a/models/boac/cohort_filter.rb
+++ b/models/boac/cohort_filter.rb
@@ -52,7 +52,9 @@ class CohortFilter
       @prep = nil
       @inactive_coe = nil
       @probation_coe = nil
-    elsif [BOACDepartments::COE, BOACDepartments::PHYSICS].include? dept
+    end
+
+    if [BOACDepartments::COE, BOACDepartments::PHYSICS].include? dept
       @inactive_asc = nil
       @intensive_asc = nil
       @team = nil

--- a/pages/boac/boac_filtered_cohort_page.rb
+++ b/pages/boac/boac_filtered_cohort_page.rb
@@ -439,7 +439,7 @@ class BOACFilteredCohortPage
     matching_ethnicity_users.flatten!
 
     # Underrepresented Minority
-    matching_minority_users = search_criteria.underrepresented_minority ? (test.searchable_data.select { |u| u[:underrepresented_minority] }) : ustest.searchable_dataer_data
+    matching_minority_users = search_criteria.underrepresented_minority ? (test.searchable_data.select { |u| u[:underrepresented_minority] }) : test.searchable_data
 
     # Gender
     matching_gender_users = []

--- a/settings.yml
+++ b/settings.yml
@@ -48,28 +48,17 @@ boac:
   nessie_assignments: true
 
   test_dept: UWASC
+  test_asc_team: FBM
   test_coe_advisor_uid: 123456
+  test_physics_levels: [Junior, Senior]
 
-  assignments_team: GOM
   assignments_max_users: 10
   assignments_term: Spring 2018
-
-  class_page_team: GOW
   class_page_max_users: 5
-
-  curated_group_team: BAM
-
-  last_activity_team: TNM
   last_activity_max_users: 3
   last_activity_context: false
   no_activity_alert_threshold: 14
-
-  navigation_team: FBM
-
-  sis_data_team: FBM
   sis_data_max_users: 100
-
-  user_search_team: TNW
   user_search_max_users: 50
 
 cal_net:

--- a/spec/boac/boac_curated_group_spec.rb
+++ b/spec/boac/boac_curated_group_spec.rb
@@ -9,7 +9,6 @@ describe 'BOAC' do
   test.curated_groups all_students
   test_student = test.cohort_members.last
   logger.debug "Test student is UID #{test_student.uid} SID #{test_student.sis_id}"
-  student_data = NessieUtils.applicable_user_search_data(all_students, test)
 
   # Initialize groups to be used later in the tests
   advisor_groups = [
@@ -253,7 +252,7 @@ describe 'BOAC' do
 
         it "shows the curated group #{group.name} members with alerts" do
           member_sids = group.members.map &:sis_id
-          group.member_data = student_data.select { |data| member_sids.include? data[:sid] }
+          group.member_data = test.searchable_data.select { |data| member_sids.include? data[:sid] }
           @homepage.expand_member_rows group
           @homepage.verify_member_alerts(@driver, group,test.advisor)
         end

--- a/spec/boac/boac_filtered_cohort_spec.rb
+++ b/spec/boac/boac_filtered_cohort_spec.rb
@@ -8,7 +8,6 @@ describe 'BOAC', order: :defined do
   test = BOACTestConfig.new
   test.filtered_cohorts all_students
   pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor
-  searchable_students = NessieUtils.applicable_user_search_data(all_students, test)
 
   before(:all) do
     @driver = Utils.launch_browser test.chrome_profile
@@ -47,7 +46,7 @@ describe 'BOAC', order: :defined do
       it "shows all the students sorted by Last Name who match #{cohort.search_criteria.list_filters}" do
         @cohort_page.click_sidebar_create_filtered
         @cohort_page.perform_search(cohort, test)
-        cohort.member_data = @cohort_page.expected_search_results(test, searchable_students, cohort.search_criteria)
+        cohort.member_data = @cohort_page.expected_search_results(test, cohort.search_criteria)
         expected_results = @cohort_page.expected_sids_by_last_name cohort.member_data
         visible_results = cohort.member_count.zero? ? [] : @cohort_page.visible_sids
         @cohort_page.wait_until(1, "Expected but not present: #{expected_results - visible_results}. Present but not expected: #{visible_results - expected_results}") do

--- a/spec/boac/boac_user_role_coe_spec.rb
+++ b/spec/boac/boac_user_role_coe_spec.rb
@@ -5,7 +5,6 @@ describe 'A CoE advisor using BOAC' do
   include Logging
 
   all_students = NessieUtils.get_all_students
-  all_student_search_data = NessieUtils.applicable_user_search_data all_students
 
   test_asc = BOACTestConfig.new
   test_asc.user_role_asc all_students
@@ -15,7 +14,7 @@ describe 'A CoE advisor using BOAC' do
 
   overlap_students = test_asc.dept_students & test_coe.dept_students
   asc_only_students = test_asc.dept_students - overlap_students
-  inactive_coe_search_data = all_student_search_data.select { |d| d[:inactive_coe] }
+  inactive_coe_search_data = test_coe.searchable_data.select { |d| d[:inactive_coe] }
   inactive_coe_sids = inactive_coe_search_data.map { |d| d[:sid] }
 
   coe_everyone_filters = BOACUtils.get_everyone_filtered_cohorts test_coe.dept
@@ -33,7 +32,7 @@ describe 'A CoE advisor using BOAC' do
     @student_page = BOACStudentPage.new @driver
 
     @coe_student_sids = test_coe.dept_students.map &:sis_id
-    @coe_student_search_data = all_student_search_data.select { |d| @coe_student_sids.include? d[:sid] }
+    @coe_student_search_data = test_coe.searchable_data.select { |d| @coe_student_sids.include? d[:sid] }
 
     @homepage.dev_auth test_coe.advisor
   end
@@ -79,7 +78,6 @@ describe 'A CoE advisor using BOAC' do
       @search_page.search inactive_coe_sids.first
       @search_page.no_results_msg(inactive_coe_sids.first).when_visible Utils.short_wait
     end
-
   end
 
   context 'performing a filtered cohort search' do
@@ -90,9 +88,11 @@ describe 'A CoE advisor using BOAC' do
       @filtered_cohort_page.wait_until(1) { @filtered_cohort_page.new_filter_option_elements.any? &:visible? }
     end
 
+    it('sees a GPA filter') { expect(@filtered_cohort_page.new_filter_option('GPA').visible?).to be true }
     it('sees a Level filter') { expect(@filtered_cohort_page.new_filter_option('Level').visible?).to be true }
     it('sees a Major filter') { expect(@filtered_cohort_page.new_filter_option('Major').visible?).to be true }
     it('sees a Units filter') { expect(@filtered_cohort_page.new_filter_option('Units Completed').visible?).to be true }
+    it('sees a Last Names filter') { expect(@filtered_cohort_page.new_filter_option('Last Names').visible?).to be true }
     it('sees a Advisor filter') { expect(@filtered_cohort_page.new_filter_option('Advisor').visible?).to be true }
     it('sees a Ethnicity filter') { expect(@filtered_cohort_page.new_filter_option('Ethnicity').visible?).to be true }
     it('sees a Gender filter') { expect(@filtered_cohort_page.new_filter_option('Gender').visible?).to be true }

--- a/util/boac_utils.rb
+++ b/util/boac_utils.rb
@@ -32,11 +32,6 @@ class BOACUtils < Utils
     @config['term_start_date']
   end
 
-  # Returns the term to be used for testing assignments
-  def self.assignments_term
-    @config['assignments_term']
-  end
-
   # Whether or not to check tooltips during tests. Checking tooltips slows down test execution.
   def self.tooltips
     @config['tooltips']


### PR DESCRIPTION
- Incorporates Physics student data into tests
- Adds a test for the Physics advisor view
- Makes another attempt to untangle the way department customizations are handled